### PR TITLE
Adding link to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # library-charts
 Helm library charts for the k8s@home Helm charts
+
+## Changelogs
+### [Common](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog)


### PR DESCRIPTION
I'm not really sure how to format this, but I hit the main landing README and saw it barren when I was looking for changelogs. I had to get help to find them, which makes me think there should be more links to them.

