### PR TITLE
TrueNAS SCALE Compatibility Patches Part-1

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.3.1
+version: 2.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -242,6 +242,22 @@ All notable changes to this application Helm chart will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.4.0]
+
+#### Added
+
+- `hostPathMounts` to mount hostPaths with a single values.yaml setting
+- Automated ownership fixing job for `hostPathMounts`
+- `envList` to use a list of environment variables in addition to the current list or template
+
+#### Changed
+
+- Set `dnsPolicy` default based on `hostNetwork` setting
+
+#### Fixed
+
+- Fixed unit-tests not correctly testing no-env scenario's
+
 ### [2.3.1]
 
 #### Fixed

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -248,7 +248,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `hostPathMounts` to mount hostPaths with a single values.yaml setting
 - Automated ownership fixing job for `hostPathMounts`
-- `envList` to use a list of environment variables in addition to the current list or template
+- `envList` to use a list of environment variables in addition to the current dict or template
 
 #### Changed
 

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -42,4 +42,5 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{- print "---" | nindent 0 -}}
     {{ include "common.secret" .  | nindent 0 }}
   {{- end -}}
+  {{ include "common.class.mountPermissions" .  | nindent 0 }}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -1,0 +1,72 @@
+{{/*
+This template serves as the blueprint for the mountPermissions job that is run
+before chart installation.
+*/}}
+{{- define "common.class.mountPermissions" -}}
+
+{{- $jobName := include "common.names.fullname" . -}}
+{{- $values := .Values -}}
+
+{{- print "---" | nindent 0 -}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}-autopermissions
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  annotations:
+   "helm.sh/hook": pre-install,pre-upgrade
+   "helm.sh/hook-weight": "-10"
+   "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+spec:
+  template:
+    metadata:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: set-mount-permissions
+          image: "alpine:3.3"
+          command:
+          - /bin/sh
+          - -c
+          - | {{ range $index, $hpm := .Values.hostPathMounts}}{{ if and $hpm.enabled $hpm.setPermissions}}
+            chown -R {{ if eq $values.podSecurityContext.runAsNonRoot false }}{{ print $values.PUID }}{{ else }}{{ print $values.podSecurityContext.runAsUser }}{{ end }}:{{ print $values.podSecurityContext.fsGroup }}  {{ print $hpm.mountPath }}{{ end }}{{ end }}
+          #args:
+          #
+          #securityContext:
+          #
+          volumeMounts:
+          {{ range $name, $hpmm := .Values.hostPathMounts }}
+          {{- if $hpmm.enabled -}}
+          {{- if $hpmm.setPermissions -}}
+          {{ if $hpmm.name }}
+            {{ $name = $hpmm.name }}
+          {{ end }}
+          - name: hostPathMounts-{{ $name }}
+            mountPath: {{ $hpmm.mountPath }}
+            {{ if $hpmm.subPath }}
+            subPath: {{ $hpmm.subPath }}
+            {{ end }}
+          {{- end -}}
+          {{- end -}}
+          {{ end }}
+      volumes:
+      {{- range $name, $hpm := .Values.hostPathMounts -}}
+      {{ if $hpm.enabled }}
+      {{ if $hpm.setPermissions }}
+      {{ if $hpm.name }}
+      {{ $name = $hpm.name }}
+      {{ end }}
+      - name: hostPathMounts-{{ $name }}
+        {{ if $hpm.emptyDir }}
+        emptyDir: {}
+        {{- else -}}
+        hostPath:
+          path: {{ required "hostPath not set" $hpm.hostPath }}
+        {{ end }}
+      {{ end }}
+      {{ end }}
+      {{- end -}}
+
+{{- end }}

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -31,7 +31,7 @@ spec:
           - /bin/sh
           - -c
           - | {{ range $index, $hpm := .Values.hostPathMounts}}{{ if and $hpm.enabled $hpm.setPermissions}}
-            chown -R {{ if eq $values.podSecurityContext.runAsNonRoot false }}{{ print $values.PUID }}{{ else }}{{ print $values.podSecurityContext.runAsUser }}{{ end }}:{{ print $values.podSecurityContext.fsGroup }}  {{ print $hpm.mountPath }}{{ end }}{{ end }}
+            chown -R {{ if not $values.podSecurityContext }}{{ print $values.PUID }}{{ else if $values.podSecurityContext.runAsNonRoot }}{{ print $values.PUID }}{{ else if $values.podSecurityContext.runAsUser }}{{ print $values.podSecurityContext.runAsUser }}{{ else }}{{ print $values.PUID }}{{ end }}:{{ if not $values.podSecurityContext }}{{ print $values.PGID }}{{ else if $values.podSecurityContext.fsGroup }}{{ print $values.podSecurityContext.fsGroup }}{{ else }}{{ print $values.PGID }}{{ end }} {{ print $hpm.mountPath }}{{ end }}{{ end }}
           #args:
           #
           #securityContext:
@@ -43,7 +43,7 @@ spec:
           {{ if $hpmm.name }}
             {{ $name = $hpmm.name }}
           {{ end }}
-          - name: hostPathMounts-{{ $name }}
+          - name: hostpathmounts-{{ $name }}
             mountPath: {{ $hpmm.mountPath }}
             {{ if $hpmm.subPath }}
             subPath: {{ $hpmm.subPath }}
@@ -58,7 +58,7 @@ spec:
       {{ if $hpm.name }}
       {{ $name = $hpm.name }}
       {{ end }}
-      - name: hostPathMounts-{{ $name }}
+      - name: hostpathmounts-{{ $name }}
         {{ if $hpm.emptyDir }}
         emptyDir: {}
         {{- else -}}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -29,8 +29,16 @@ The main container included in the controller.
   lifecycle:
     {{- toYaml . | nindent 2 }}
   {{- end }}
-  {{- if or .Values.env .Values.envTpl .Values.envValueFrom }}
   env:
+  {{- if or .Values.envList .Values.env .Values.envTpl .Values.envValueFrom }}
+  {{- range $envList := .Values.envList }}
+  {{- if and $envList.name $envList.value }}
+    - name: {{ $envList.name }}
+      value: {{ $envList.value | quote }}
+  {{- else }}
+    {{- fail "Please specify name/value for environment variable" }}
+  {{- end }}
+  {{- end}}
   {{- range $key, $value := .Values.env }}
   - name: {{ $key }}
     value: {{ $value | quote }}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -30,15 +30,15 @@ The main container included in the controller.
     {{- toYaml . | nindent 2 }}
   {{- end }}
   env:
-    - name: PUID
-      value: {{ .Values.PUID | quote }}
-    - name: PGID
-      value: {{ .Values.PGID | quote }}
+  - name: PUID
+    value: {{ .Values.PUID | quote }}
+  - name: PGID
+    value: {{ .Values.PGID | quote }}
   {{- if or .Values.envList .Values.env .Values.envTpl .Values.envValueFrom }}
   {{- range $envList := .Values.envList }}
   {{- if and $envList.name $envList.value }}
-    - name: {{ $envList.name }}
-      value: {{ $envList.value | quote }}
+  - name: {{ $envList.name }}
+    value: {{ $envList.value | quote }}
   {{- else }}
     {{- fail "Please specify name/value for environment variable" }}
   {{- end }}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -30,6 +30,10 @@ The main container included in the controller.
     {{- toYaml . | nindent 2 }}
   {{- end }}
   env:
+    - name: PUID
+      value: {{ .Values.PUID | quote }}
+    - name: PGID
+      value: {{ .Values.PGID | quote }}
   {{- if or .Values.envList .Values.env .Values.envTpl .Values.envValueFrom }}
   {{- range $envList := .Values.envList }}
   {{- if and $envList.name $envList.value }}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -64,27 +64,9 @@ The main container included in the controller.
   {{- end }}
   {{- end }}
   {{- include "common.controller.ports" . | trim | nindent 2 }}
+  {{- with (include "common.controller.volumeMounts" . | trim) }}
   volumeMounts:
-  {{- range $index, $PVC := .Values.persistence }}
-  {{- if $PVC.enabled }}
-  - mountPath: {{ $PVC.mountPath | default (printf "/%v" $index) }}
-    name: {{ $index }}
-  {{- if $PVC.subPath }}
-    subPath: {{ $PVC.subPath }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.additionalVolumeMounts }}
-    {{- toYaml .Values.additionalVolumeMounts | nindent 2 }}
-  {{- end }}
-  {{- if eq .Values.controllerType "statefulset"  }}
-  {{- range $index, $vct := .Values.volumeClaimTemplates }}
-  - mountPath: {{ $vct.mountPath }}
-    name: {{ $vct.name }}
-  {{- if $vct.subPath }}
-    subPath: {{ $vct.subPath }}
-  {{- end }}
-  {{- end }}
+    {{- . | nindent 2 }}
   {{- end }}
   {{- include "common.controller.probes" . | nindent 2 }}
   {{- with .Values.resources }}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -29,12 +29,8 @@ The main container included in the controller.
   lifecycle:
     {{- toYaml . | nindent 2 }}
   {{- end }}
-  env:
-  - name: PUID
-    value: {{ .Values.PUID | quote }}
-  - name: PGID
-    value: {{ .Values.PGID | quote }}
   {{- if or .Values.envList .Values.env .Values.envTpl .Values.envValueFrom }}
+  env:
   {{- range $envList := .Values.envList }}
   {{- if and $envList.name $envList.value }}
   - name: {{ $envList.name }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -24,8 +24,7 @@ hostNetwork: {{ . }}
 hostname: {{ . }}
 {{- end }}
 {{- if .Values.dnsPolicy }}
-{{- with .Values.dnsPolicy }}
-dnsPolicy: {{ . }}
+ dnsPolicy: {{ .Values.dnsPolicy }}
 {{- end }}
 {{- else if .Values.hostNetwork }}
 dnsPolicy: "ClusterFirstWithHostNet"

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -26,6 +26,7 @@ hostname: {{ . }}
 {{- if .Values.dnsPolicy }}
 {{- with .Values.dnsPolicy }}
 dnsPolicy: {{ . }}
+{{- end }}
 {{- else if .Values.hostNetwork }}
 dnsPolicy: "ClusterFirstWithHostNet"
 {{- else }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -25,7 +25,6 @@ hostname: {{ . }}
 {{- end }}
 {{- if .Values.dnsPolicy }}
  dnsPolicy: {{ .Values.dnsPolicy }}
-{{- end }}
 {{- else if .Values.hostNetwork }}
 dnsPolicy: "ClusterFirstWithHostNet"
 {{- else }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -23,8 +23,13 @@ hostNetwork: {{ . }}
 {{- with .Values.hostname }}
 hostname: {{ . }}
 {{- end }}
+{{- if .Values.dnsPolicy }}
 {{- with .Values.dnsPolicy }}
 dnsPolicy: {{ . }}
+{{- else if .Values.hostNetwork }}
+dnsPolicy: "ClusterFirstWithHostNet"
+{{- else }}
+dnsPolicy: ClusterFirst
 {{- end }}
 {{- with .Values.dnsConfig }}
 dnsConfig:

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -24,7 +24,7 @@ hostNetwork: {{ . }}
 hostname: {{ . }}
 {{- end }}
 {{- if .Values.dnsPolicy }}
- dnsPolicy: {{ .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy }}
 {{- else if .Values.hostNetwork }}
 dnsPolicy: "ClusterFirstWithHostNet"
 {{- else }}

--- a/charts/stable/common/templates/lib/controller/_volumemounts.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumemounts.tpl
@@ -14,7 +14,7 @@ Volumes included by the controller.
 {{- end }}
 
 {{- if .Values.additionalVolumeMounts }}
-  {{- toYaml .Values.additionalVolumeMounts | nindent 2 }}
+{{- toYaml .Values.additionalVolumeMounts | nindent 0 }}
 {{- end }}
 
 {{- if eq .Values.controllerType "statefulset"  }}

--- a/charts/stable/common/templates/lib/controller/_volumemounts.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumemounts.tpl
@@ -1,7 +1,8 @@
-
 {{/*
 Volumes included by the controller.
 */}}
+{{- define "common.controller.volumeMounts" -}}
+
 {{- range $index, $PVC := .Values.persistence }}
 {{- if $PVC.enabled }}
 - mountPath: {{ $PVC.mountPath | default (printf "/%v" $index) }}
@@ -34,7 +35,7 @@ Creates mountpoints to mount hostPaths directly to the container
 {{ if $hpm.name }}
   {{ $name = $hpm.name }}
 {{ end }}
-- name: customstorage-{{ $name }}
+- name: hostpathmounts-{{ $name }}
   mountPath: {{ $hpm.mountPath }}
   {{ if $hpm.subPath }}
   subPath: {{ $hpm.subPath }}
@@ -44,6 +45,5 @@ Creates mountpoints to mount hostPaths directly to the container
   {{ end }}
 {{- end -}}
 {{ end }}
-
 
 {{- end -}}

--- a/charts/stable/common/templates/lib/controller/_volumemounts.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumemounts.tpl
@@ -1,0 +1,49 @@
+
+{{/*
+Volumes included by the controller.
+*/}}
+{{- range $index, $PVC := .Values.persistence }}
+{{- if $PVC.enabled }}
+- mountPath: {{ $PVC.mountPath | default (printf "/%v" $index) }}
+  name: {{ $index }}
+{{- if $PVC.subPath }}
+  subPath: {{ $PVC.subPath }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.additionalVolumeMounts }}
+  {{- toYaml .Values.additionalVolumeMounts | nindent 2 }}
+{{- end }}
+
+{{- if eq .Values.controllerType "statefulset"  }}
+{{- range $index, $vct := .Values.volumeClaimTemplates }}
+- mountPath: {{ $vct.mountPath }}
+  name: {{ $vct.name }}
+{{- if $vct.subPath }}
+  subPath: {{ $vct.subPath }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creates mountpoints to mount hostPaths directly to the container
+*/}}
+{{ range $name, $hpm := .Values.hostPathMounts }}
+{{- if $hpm.enabled -}}
+{{ if $hpm.name }}
+  {{ $name = $hpm.name }}
+{{ end }}
+- name: customstorage-{{ $name }}
+  mountPath: {{ $hpm.mountPath }}
+  {{ if $hpm.subPath }}
+  subPath: {{ $hpm.subPath }}
+  {{ end }}
+  {{ if $hpm.readOnly }}
+  readOnly: {{ $hpm.readOnly }}
+  {{ end }}
+{{- end -}}
+{{ end }}
+
+
+{{- end -}}

--- a/charts/stable/common/templates/lib/controller/_volumes.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumes.tpl
@@ -58,7 +58,7 @@ Creates Volumes for hostPaths which can be directly mounted to a container
 {{ if $hpm.name }}
 {{ $name = $hpm.name }}
 {{ end }}
-- name: customstorage-{{ $name }}
+- name: hostpathmounts-{{ $name }}
   {{ if $hpm.emptyDir }}
   emptyDir: {}
   {{- else -}}

--- a/charts/stable/common/templates/lib/controller/_volumes.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumes.tpl
@@ -48,4 +48,24 @@ Volumes included by the controller.
 {{- if .Values.additionalVolumes }}
   {{- toYaml .Values.additionalVolumes | nindent 0 }}
 {{- end }}
+
+
+{{/*
+Creates Volumes for hostPaths which can be directly mounted to a container
+*/}}
+{{- range $name, $hpm := .Values.hostPathMounts -}}
+{{ if $hpm.enabled }}
+{{ if $hpm.name }}
+{{ $name = $hpm.name }}
+{{ end }}
+- name: customstorage-{{ $name }}
+  {{ if $hpm.emptyDir }}
+  emptyDir: {}
+  {{- else -}}
+  hostPath:
+    path: {{ required "hostPath not set" $hpm.hostPath }}
+  {{ end }}
+{{ end }}
+{{- end -}}
+
 {{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -75,7 +75,8 @@ envFrom: []
 # When using hostNetwork make sure you set dnsPolicy to ClusterFirstWithHostNet
 hostNetwork: false
 
-dnsPolicy: ClusterFirst
+# Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true.
+# dnsPolicy: ClusterFirst
 
 # Optional DNS settings, configuring the ndots option may resolve
 # nslookup issues on some Kubernetes setups.

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -168,6 +168,8 @@ service:
   annotations: {}
   labels: {}
 
+  ## additionalServices can be created as either a dict or a list.
+  ## In case of a dict, please use the nameSuffix as dict name
   additionalServices: []
   # - enabled: false
   #   nameSuffix: api

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -90,12 +90,6 @@ hostNetwork: false
 # for more information.
 enableServiceLinks: true
 
-# Sets the PUID env-var and is used to process ownership of hostPathMounts
-PUID: 568
-
-# Sets the PGID env-var and is used to process ownership of hostPathMounts
-PGID: 568
-
 # Configure the Security Context for the Pod
 podSecurityContext: {}
 

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -258,6 +258,16 @@ persistence:
       enabled: true
     mountPath: /shared
 
+# Mount a folder on the host directly to the containers
+# hostPathMount:
+#   - name: "data"
+#     enabled: false
+#     emptyDir: false
+#     mountPath: "/data"
+#     subPath: some-subpath
+#     hostPath: ""
+#     readOnly: false
+
 additionalVolumes: []
 
 additionalVolumeMounts: []

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -265,7 +265,7 @@ persistence:
     mountPath: /shared
 
 # Mount a folder on the host directly to the containers
-# hostPathMount:
+# hostPathMounts:
 #   - name: "data"
 #     enabled: false
 #     emptyDir: false

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -41,6 +41,10 @@ secret: {}
 env: {}
   # TZ: UTC
 
+envList: []
+  # - name: TZ
+  #   value: UTC
+
 ## Variables with values set from templates, example
 ## With a release name of: demo, the example env value will be: demo-admin
 envTpl: {}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -90,6 +90,12 @@ hostNetwork: false
 # for more information.
 enableServiceLinks: true
 
+# Sets the PUID env-var and is used to process ownership of hostPathMounts
+PUID: 568
+
+# Sets the PGID env-var and is used to process ownership of hostPathMounts
+PGID: 568
+
 # Configure the Security Context for the Pod
 podSecurityContext: {}
 

--- a/test/stable/common/container_spec.rb
+++ b/test/stable/common/container_spec.rb
@@ -73,63 +73,6 @@ class Test < ChartTest
       end
     end
 
-    describe 'container::PUID and PGID' do
-      it 'Check PUID and PGID default to 568' do
-        values = {}
-        chart.value values
-        deployment = chart.resources(kind: "Deployment").first
-        containers = deployment["spec"]["template"]["spec"]["containers"]
-        mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal("PUID", mainContainer["env"][0]["name"])
-        assert_equal("568", mainContainer["env"][0]["value"])
-        assert_equal("PGID", mainContainer["env"][1]["name"])
-        assert_equal("568", mainContainer["env"][1]["value"])
-      end
-
-      it 'set "PUID"' do
-          values = {
-          PUID: '666'
-        }
-        chart.value values
-        deployment = chart.resources(kind: "Deployment").first
-        containers = deployment["spec"]["template"]["spec"]["containers"]
-        mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal("PUID", mainContainer["env"][0]["name"])
-        assert_equal("666", mainContainer["env"][0]["value"])
-        assert_equal("PGID", mainContainer["env"][1]["name"])
-        assert_equal("568", mainContainer["env"][1]["value"])
-      end
-
-      it 'set "PGID"' do
-          values = {
-          PGID: '999'
-        }
-        chart.value values
-        deployment = chart.resources(kind: "Deployment").first
-        containers = deployment["spec"]["template"]["spec"]["containers"]
-        mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal("PUID", mainContainer["env"][0]["name"])
-        assert_equal("568", mainContainer["env"][0]["value"])
-        assert_equal("PGID", mainContainer["env"][1]["name"])
-        assert_equal("999", mainContainer["env"][1]["value"])
-      end
-
-      it 'set both "PUID" and "PGID"' do
-          values = {
-          PUID: '666',
-          PGID: '999'
-        }
-        chart.value values
-        deployment = chart.resources(kind: "Deployment").first
-        containers = deployment["spec"]["template"]["spec"]["containers"]
-        mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal("PUID", mainContainer["env"][0]["name"])
-        assert_equal("666", mainContainer["env"][0]["value"])
-        assert_equal("PGID", mainContainer["env"][1]["name"])
-        assert_equal("999", mainContainer["env"][1]["value"])
-      end
-    end
-
     describe 'container::environment settings' do
       it 'Check no environment variables' do
         values = {}
@@ -137,7 +80,7 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_nil(mainContainer["env"][2])
+        assert_nil(mainContainer["env"])
       end
 
       it 'set "static" environment variables' do
@@ -150,8 +93,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][2]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][2]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][0]["value"])
       end
       
       it 'set "list" of "static" environment variables' do
@@ -168,8 +111,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][2]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][2]["value"])
+        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][0]["value"])
       end
       
       it 'set both "list" AND "dict" of "static" environment variables' do
@@ -189,10 +132,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][2]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][2]["value"])
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][3]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][3]["value"])
+        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][0]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][1]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][1]["value"])
       end
 
       it 'set "valueFrom" environment variables' do
@@ -209,8 +152,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envValueFrom].keys[0].to_s, mainContainer["env"][2]["name"])
-        assert_equal(values[:envValueFrom].values[0][:fieldRef][:fieldPath], mainContainer["env"][2]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:envValueFrom].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:envValueFrom].values[0][:fieldRef][:fieldPath], mainContainer["env"][0]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set "static" and "Dynamic/Tpl" environment variables' do
@@ -226,10 +169,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][2]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][2]["value"])
-        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][3]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][3]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][0]["value"])
+        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][1]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][1]["value"])
       end
       
       it 'set "Dynamic/Tpl" environment variables' do
@@ -242,8 +185,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][2]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][2]["value"])
+        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][0]["value"])
       end
       
       it 'set "static" secret variables' do

--- a/test/stable/common/job.rb
+++ b/test/stable/common/job.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+class Test < ChartTest
+  @@chart = Chart.new('helper-charts/common-test')
+  
+  describe @@chart.name do
+  
+    describe 'job::permissions' do
+      it 'exists by default' do
+        job = chart.resources(kind: "Job").first
+        assert_equal("set-mount-permissions", job["spec"]["template"]["spec"]["containers"][0]["name"])
+      end
+      it 'has no volumes by default' do
+        job = chart.resources(kind: "Job").first
+        assert_nil(job["spec"]["template"]["spec"]["volumes"])
+      end
+      it 'has no volumeMounts by default' do
+        job = chart.resources(kind: "Job").first
+        assert_nil(job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"])
+      end
+      
+      it 'hostPathMounts do not affect permissions job by default' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                mountPath: "/data",
+                hostPath: "/tmp"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        assert_nil(job["spec"]["template"]["spec"]["volumes"])
+        assert_nil(job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"])
+      end
+      it 'hostPathMounts.setPermissions adds volume(mounts)' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        assert_equal("hostpathmounts-data", job["spec"]["template"]["spec"]["volumes"][0]["name"])
+        assert_equal("hostpathmounts-data", job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]["name"])
+      end
+      it 'supports multiple hostPathMounts' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+
+        # Check that all hostPathMounts volumes have mounts
+        values[:hostPathMounts].each { |value|
+          volumeMount = mainContainer["volumeMounts"].find{ |v| v["name"] == "hostpathmounts-" + value[:name].to_s }
+          refute_nil(volumeMount)
+        }
+      end
+      
+      it 'supports setting mountPath' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+
+        volumeMount = mainContainer["volumeMounts"].find{ |v| v["name"] == "hostpathmounts-data" }
+        refute_nil(volumeMount)
+        assert_equal("/data", volumeMount["mountPath"])
+      end
+      
+      it 'could mount multiple volumes' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        volumes = job["spec"]["template"]["spec"]["volumes"]
+
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-data"}
+        refute_nil(volume)
+        assert_equal('/tmp1', volume["hostPath"]["path"])
+
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-config"}
+        refute_nil(volume)
+        assert_equal('/tmp2', volume["hostPath"]["path"])
+      end
+      
+      it 'emptyDir can be enabled' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                emptyDir: true,
+                mountPath: "/data"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        volumes = job["spec"]["template"]["spec"]["volumes"]
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-data"}
+        refute_nil(volume)
+        assert_equal(Hash.new, volume["emptyDir"])
+      end
+      
+      it 'can process default (568:568) permissions for multiple volumes' do
+        results= {
+          command: ["/bin/sh", "-c", "chown -R 568:568 /data
+chown -R 568:568 /config
+"]
+        }
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+        assert_equal(results[:command], mainContainer["command"])
+      end
+      
+      it 'outputs default permissions with irrelevant podSecurityContext' do
+        results= {
+          command: ["/bin/sh", "-c", "chown -R 568:568 /data
+chown -R 568:568 /config
+"]
+        }
+        values = {
+          podSecurityContext: {
+            allowPrivilegeEscalation: false
+          },
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+        assert_equal(results[:command], mainContainer["command"])
+      end
+      
+      it 'outputs fsgroup permissions for multiple volumes when set' do
+        results= {
+          command: ["/bin/sh", "-c", "chown -R 568:666 /data
+chown -R 568:666 /config
+"]
+        }
+        values = {
+          podSecurityContext: {
+            fsGroup: 666
+          },
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+        assert_equal(results[:command], mainContainer["command"])
+      end
+      
+      it 'outputs runAsUser permissions for multiple volumes when set' do
+        results= {
+          command: ["/bin/sh", "-c", "chown -R 999:568 /data
+chown -R 999:568 /config
+"]
+        }
+        values = {
+          podSecurityContext: {
+            runAsUser: 999
+          },
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+        assert_equal(results[:command], mainContainer["command"])
+      end
+      
+      it 'outputs fsGroup AND runAsUser permissions for multiple volumes when both are set' do
+        results= {
+          command: ["/bin/sh", "-c", "chown -R 999:666 /data
+chown -R 999:666 /config
+"]
+        }
+        values = {
+          podSecurityContext: {
+            fsGroup: 666,
+            runAsUser: 999
+          },
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                setPermissions: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        job = chart.resources(kind: "Job").first
+        mainContainer = job["spec"]["template"]["spec"]["containers"][0]
+        assert_equal(results[:command], mainContainer["command"])
+      end
+    end
+  end
+end
+
+

--- a/test/stable/common/pod_spec.rb
+++ b/test/stable/common/pod_spec.rb
@@ -18,6 +18,56 @@ class Test < ChartTest
       end
     end
 
+    describe 'pod::hostNetwork' do
+      it 'defaults to nil' do
+        deployment = chart.resources(kind: "Deployment").first
+        assert_nil(deployment["spec"]["template"]["spec"]["hostNetwork"])
+      end
+
+      it 'can be enabled' do
+        values = {
+          hostNetwork: true
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        assert_equal(true, deployment["spec"]["template"]["spec"]["hostNetwork"])
+      end
+    end
+
+    describe 'pod::dnsPolicy' do
+      it 'defaults to "ClusterFirst" without hostNetwork' do
+        deployment = chart.resources(kind: "Deployment").first
+        assert_equal("ClusterFirst", deployment["spec"]["template"]["spec"]["dnsPolicy"])
+      end
+  
+      it 'defaults to "ClusterFirst" when hostNetwork: false' do
+        values = {
+          hostNetwork: false
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        assert_equal("ClusterFirst", deployment["spec"]["template"]["spec"]["dnsPolicy"])
+      end
+
+      it 'defaults to "ClusterFirstWithHostNet" when hostNetwork: true' do
+        values = {
+          hostNetwork: true
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        assert_equal("ClusterFirstWithHostNet", deployment["spec"]["template"]["spec"]["dnsPolicy"])
+      end
+
+      it 'accepts manual override' do
+        values = {
+          dnsPolicy: "None"
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        assert_equal("None", deployment["spec"]["template"]["spec"]["dnsPolicy"])
+      end
+    end
+
     describe 'pod::additional containers' do
       it 'accepts static additionalContainers' do
         values = {
@@ -209,6 +259,57 @@ class Test < ChartTest
         volume = volumes.find{ |v| v["name"] == "config"}
         refute_nil(volume)
         assert_equal("1Gi", volume["emptyDir"]["sizeLimit"])
+      end
+    end
+    
+    describe 'pod::hostPathMounts' do
+      it 'multiple volumes' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                mountPath: "/data",
+                hostPath: "/tmp1"
+          },
+          {
+                name: "config",
+                enabled: true,
+                mountPath: "/config",
+                hostPath: "/tmp2"
+          }
+          ]
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        volumes = deployment["spec"]["template"]["spec"]["volumes"]
+
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-data"}
+        refute_nil(volume)
+        assert_equal('/tmp1', volume["hostPath"]["path"])
+
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-config"}
+        refute_nil(volume)
+        assert_equal('/tmp2', volume["hostPath"]["path"])
+      end
+      
+      it 'emptyDir can be enabled' do
+        values = {
+          hostPathMounts: [
+          {
+                name: "data",
+                enabled: true,
+                emptyDir: true,
+                mountPath: "/data"
+          }
+          ]
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        volumes = deployment["spec"]["template"]["spec"]["volumes"]
+        volume = volumes.find{ |v| v["name"] == "hostpathmounts-data"}
+        refute_nil(volume)
+        assert_equal(Hash.new, volume["emptyDir"])
       end
     end
   end


### PR DESCRIPTION
**Description of the change**

As discussed with @onedr0p I would slowly start porting SCALE compatibility to KAH.

This PR ports the "low hanging fruit", the non-breaking changes.


**Benefits**

- Adds the option to create both an env-var dict (env) and a env-var list (envList)

_This enables us to create pre-set options in the SCALE UI or Helm charts AND still have a seperate place for users to drop their own env-vars (the list). SCALE UI does not offer to do both with only the dict (env) available._

- Turns volumeMounts into a seperate controller like Volumes

_Volumes was a seperate controller, this does the same to Volumes mounts, it improves readability and expandability._

- Add hostPathMounts

_This option creates both a volume and a volumemount, based on a hostPath. It's basically a combined "additionalVolumes" and "additionalVolumeMounts", however: it includeds "PVC-like" automated fixing of permissions and, when used in a SCALE GUI, gives a better UX._

- set dnsPolicy defaults based on hostNetwork setting

_This changes sets the default of dnsPolicy based on hostNetwork, because both settings of hostNetworking have a very clearly defined "best practice" default for dnsPolicy_

**Possible drawbacks**

- It creates slight redundancy in options

- The automated hostPathMounts permissions job gives a slightly increased risk of bugs/issues

- hostPathMounts are not the prefered or most secure storage option and thus should not be used as a default option for normal helm charts, however: it's one of the prefered ways for TrueNas SCALE.

Most of these issues are somewhat covered by including unittests for all added features.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

- Also fixes a small bug where no-env unittest was giving false results
- Adds Unit-tests for hostNetwork
- Adds Unit-tests for dnsPolicy
- Includes Unit-tests for envList
- Includes Unit-tests for hostPathMounts
- Includes Unit-tests for the permission setting job

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
