### PR TITLE
TrueNAS SCALE Compatibility Patches Part-2

### DIFF
--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -249,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Horizontal Pod Autoscaler`
 - Can now use "HTTP" or "HTTPS" as port protocol (which use TCP under-the-hood)
 - Add option to automatically generate a configmap for use with the TrueNAS SCALE UI portal-button
+- Added option to use TrueNAS SCALE default storageClass by using `SCALE-ZFS` storageClass
 
 #### Changed
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -247,6 +247,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Added `Horizontal Pod Autoscaler`
+- Can now use "HTTP" or "HTTPS" as port protocol (which use TCP under-the-hood)
+- Add option to automatically generate a configmap for use with the TrueNAS SCALE UI portal-button
+
+#### Changed
+
+- Port protocol gets used to determine install-notes URL (http or https)
 
 ### [2.4.0]
 

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -44,4 +44,5 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{ include "common.secret" .  | nindent 0 }}
   {{- end -}}
   {{ include "common.class.mountPermissions" .  | nindent 0 }}
+  {{ include "common.classes.portal" .  | nindent 0 }}
 {{- end -}}

--- a/charts/stable/common/templates/_notes.tpl
+++ b/charts/stable/common/templates/_notes.tpl
@@ -3,6 +3,11 @@ Default NOTES.txt content.
 */}}
 {{- define "common.notes.defaultNotes" -}}
 {{- $svcPort := .Values.service.port.port -}}
+{{- $svcProtocol := .Values.service.port.protocol -}}
+{{- $prefix := "http" -}}
+{{- if eq $svcProtocol "HTTPS" }}
+{{- $prefix = "https" }}
+{{- end }}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
@@ -11,15 +16,15 @@ Default NOTES.txt content.
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo {{ $prefix }}://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ include "common.names.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ $svcPort }}
+  echo {{ $prefix }}://$SERVICE_IP:{{ $svcPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
+  echo "Visit {{ $prefix }}://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ $svcPort }}
 {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/classes/_portal.tpl
+++ b/charts/stable/common/templates/classes/_portal.tpl
@@ -64,8 +64,7 @@ data:
   host: {{ $host | quote }}
   port: {{ $port | quote }}
   path: {{ $path | quote }}
-  url: {{ ( printf "%v%v%v%v%v%v" $protocol "://" $host ":" $port $path ) | quote }}
-
+  url: {{ ( printf "%v://%v:%v%v" $protocol $host $port $path ) | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_portal.tpl
+++ b/charts/stable/common/templates/classes/_portal.tpl
@@ -1,0 +1,71 @@
+{{- define "common.classes.portal" -}}
+
+{{- if .Values.portal }}
+{{- if .Values.portal.enabled }}
+{{- $host := "$node_ip" }}
+{{- $port := 443 }}
+{{- $protocol := "https" }}
+{{- $portProtocol := "" }}
+{{- $path := "/" }}
+
+{{- if hasKey .Values "ingress" }}
+  {{- if .Values.ingress.enabled }}
+    {{- range .Values.ingress.hosts }}
+    {{- if .hostTpl }}
+    {{ $host = ( tpl .hostTpl $ ) }}
+    {{- else if .host }}
+    {{ $host = .host }}
+    {{- else }}
+    {{ $host = "$node_ip" }}
+    {{- end }}
+    {{- if .paths }}
+    {{- $path = (first .paths).path  }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if and ( .Values.portal.ingressPort ) ( ne $host "$node_ip" ) }}
+  {{- $port = .Values.portal.ingressPort }}
+{{- else  if eq $host "$node_ip" }}
+  {{- if eq .Values.service.type "NodePort" }}
+    {{- $port = .Values.service.port.nodePort }}
+    {{- if or ( eq .Values.service.port.protocol "HTTP" ) ( eq .Values.service.port.protocol "HTTPS" ) }}
+      {{- $portProtocol = .Values.service.port.protocol }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if and ( $portProtocol ) ( eq $host "$node_ip" ) }}
+  {{- $protocol = $portProtocol }}
+{{- else if and ( ne $host "$node_ip" ) }}
+  {{- if $.Values.ingress.tls }}
+    {{- $protocol = "https" }}
+  {{- end }}
+{{- end }}
+
+{{- if and ( .Values.portal.host ) ( eq $host "$node_ip" ) }}
+  {{- $host = .Values.portal.host }}
+{{- end }}
+
+{{- if and ( .Values.portal.path ) }}
+  {{- $path = .Values.portal.path }}
+{{- end }}
+
+{{- print "---" | nindent 0 -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portal
+  labels: {{ include "common.labels" . | nindent 4 }}
+data:
+  protocol: {{ $protocol }}
+  host: {{ $host | quote }}
+  port: {{ $port | quote }}
+  path: {{ $path | quote }}
+  url: {{ ( printf "%v%v%v%v%v%v" $protocol "://" $host ":" $port $path ) | quote }}
+
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -37,6 +37,6 @@ spec:
     requests:
       storage: {{ required (printf "size is required for PVC %v" $pvcName) $values.size | quote }}
   {{- if $values.storageClass }}
-  storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else }}{{ $values.storageClass | quote }}{{- end }}
+  storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_service_ports.tpl
+++ b/charts/stable/common/templates/classes/_service_ports.tpl
@@ -13,7 +13,15 @@ Render all the ports and additionalPorts for a Service object.
   {{- range $_ := $ports }}
   - port: {{ .port }}
     targetPort: {{ .targetPort | default .name | default "http" }}
-    protocol: {{ .protocol | default "TCP" }}
+    {{- if .protocol }}
+    {{- if or ( eq .protocol "HTTP" ) ( eq .protocol "HTTPS" ) ( eq .protocol "TCP" ) }}
+    protocol: TCP
+    {{- else }}
+    protocol: {{ .protocol }}
+    {{- end }}
+    {{- else }}
+    protocol: TCP
+    {{- end }}
     name: {{ .name | default "http" }}
     {{- if (and (eq $.svcType "NodePort") (not (empty .nodePort))) }}
     nodePort: {{ .nodePort }}

--- a/charts/stable/common/templates/lib/controller/_ports.tpl
+++ b/charts/stable/common/templates/lib/controller/_ports.tpl
@@ -36,7 +36,15 @@ ports:
   {{- fail (printf "Our charts do not support named ports for targetPort. (port name %s, targetPort %s)" .name .targetPort) }}
   {{- end }}
   containerPort: {{ .targetPort | default .port }}
-  protocol: {{ .protocol | default "TCP" }}
+  {{- if .protocol }}
+  {{- if or ( eq .protocol "HTTP" ) ( eq .protocol "HTTPS" ) ( eq .protocol "TCP" ) }}
+  protocol: TCP
+  {{- else }}
+  protocol: {{ .protocol }}
+  {{- end }}
+  {{- else }}
+  protocol: TCP
+  {{- end }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -266,6 +266,8 @@ persistence:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
+    ## If set to "SCALE-ZFS" the default provisioner for TrueNAS SCALE is used.
+    ##
     # storageClass: "-"
     ##
     ## If you want to reuse an existing claim, you can pass the name of the PVC using

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -160,7 +160,9 @@ service:
     port:
     ## name defaults to http
     name:
-    protocol: TCP
+    ## Accepts: HTTP, HTTPS, TCP and UDP
+    ## HTTPS and HTTPS spawn a TCP service and get used for internal URL and name generation
+    protocol: HTTP
     ## Specify a service targetPort if you wish to differ the service port from the application port.
     ## If targetPort is specified, this port number is used in the container definition instead of
     ## service.port.port. Therefore named ports are not supported for this field.
@@ -240,6 +242,18 @@ ingress:
   #   #  - secretName: chart-example-tls
   #   #    hosts:
   #   #      - chart-example.local
+
+# ## Adds a portal configmap for use with TrueNAS SCALE
+# ## This should not be enabled on other systems than TrueNAS SCALE,
+# ## Because it requires a seperate namespace for each chart.
+# portal:
+#   enabled: false
+#   ## Override default port used for the portal button when using ingress.
+#   # ingressPort: 80
+#   ## Override hostname used for the portal button when using nodePort
+#   # host: 192.168.0.2
+#   ## Override the path used in the url
+#   # path: /example
 
 persistence:
   config:

--- a/test/stable/common/configmap.rb
+++ b/test/stable/common/configmap.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+class Test < ChartTest
+  @@chart = Chart.new('helper-charts/common-test')
+
+  describe @@chart.name do
+    describe 'configmap::general' do
+      it 'does not exist by default' do
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_nil(configmap)
+      end
+    end
+
+    describe 'configmap::portal-defaults' do
+      it 'can be enabled' do
+        values = {
+          portal: {
+            enabled: true
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        refute_nil(configmap)
+      end
+      it 'is named "portal"' do
+        values = {
+          portal: {
+            enabled: true
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("portal", configmap["metadata"]["name"])
+      end
+      it 'uses "$node_ip" by default' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("$node_ip", configmap["data"]["host"])
+      end
+      it 'uses port "443" by default' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("443", configmap["data"]["port"])
+      end
+      it 'uses protocol "https" by default' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("https", configmap["data"]["protocol"])
+      end
+      it 'uses path "/" by default' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("/", configmap["data"]["path"])
+      end
+    end
+    describe 'configmap::portal-overrides' do
+      it 'ingressPort can be overridden' do
+        values = {
+          portal: {
+            enabled: true,
+            ingressPort: "666"
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal(values[:portal][:ingressPort], configmap["data"]["port"])
+      end
+      it 'nodePort Host can be overridden' do
+        values = {
+          portal: {
+            enabled: true,
+            host: "test.host"
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal(values[:portal][:host], configmap["data"]["host"])
+      end
+      it 'path  can be overridden' do
+        values = {
+          portal: {
+            enabled: true,
+            path: "/path"
+          },
+          ingress: {
+            enabled: false
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal(values[:portal][:path], configmap["data"]["path"])
+      end
+    end
+    describe 'configmap::portal-nodePort' do
+      it 'nodePort host defaults to "$node_ip"' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          },
+          service: {
+            type: "NodePort",
+            port: {
+              nodePort: 666
+            }
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("$node_ip", configmap["data"]["host"])
+      end
+      it 'nodePort port defaults to the nodePort' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          },
+          service: {
+            type: "NodePort",
+            port: {
+              nodePort: 666
+            }
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("666", configmap["data"]["port"])
+      end
+      it 'uses nodeport port protocol as protocol (HTTPS)' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          },
+          service: {
+            type: "NodePort",
+            port: {
+              nodePort: 666,
+              protocol: "HTTPS"
+            }
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
+      end
+      it 'uses nodeport port protocol as protocol (HTTP)' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: false
+          },
+          service: {
+            type: "NodePort",
+            port: {
+              nodePort: 666,
+              protocol: "HTTP"
+            }
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
+      end
+    end
+    describe 'configmap::portal-Ingress' do
+      it 'uses ingress host' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: true,
+            hosts: [
+              {
+                host: "test.domain",
+                paths:
+                [
+                  {
+                    path: "/test"
+                  }
+                ]
+
+              }
+            ]
+          }
+        }
+        chart.value values
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("test.domain", configmap["data"]["host"])
+      end
+      it 'uses ingress path' do
+        values = {
+          portal: {
+            enabled: true
+          },
+          ingress: {
+            enabled: true,
+            hosts: [
+              {
+                host: "test.domain",
+                paths:
+                [
+                  {
+                    path: "/test"
+                  }
+                ]
+
+              }
+            ]
+          }
+        }
+        chart.value values
+        configmap = chart.resources(kind: "ConfigMap").first
+        assert_equal("/test", configmap["data"]["path"])
+      end
+    end
+  end
+end

--- a/test/stable/common/configmap_spec.rb
+++ b/test/stable/common/configmap_spec.rb
@@ -23,6 +23,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         refute_nil(configmap)
       end
+
       it 'is named "portal"' do
         values = {
           portal: {
@@ -33,6 +34,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("portal", configmap["metadata"]["name"])
       end
+
       it 'uses "$node_ip" by default' do
         values = {
           portal: {
@@ -46,6 +48,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("$node_ip", configmap["data"]["host"])
       end
+
       it 'uses port "443" by default' do
         values = {
           portal: {
@@ -59,6 +62,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("443", configmap["data"]["port"])
       end
+
       it 'uses protocol "https" by default' do
         values = {
           portal: {
@@ -72,6 +76,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("https", configmap["data"]["protocol"])
       end
+
       it 'uses path "/" by default' do
         values = {
           portal: {
@@ -86,6 +91,7 @@ class Test < ChartTest
         assert_equal("/", configmap["data"]["path"])
       end
     end
+
     describe 'configmap::portal-overrides' do
       it 'ingressPort can be overridden' do
         values = {
@@ -98,6 +104,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal(values[:portal][:ingressPort], configmap["data"]["port"])
       end
+
       it 'nodePort Host can be overridden' do
         values = {
           portal: {
@@ -112,6 +119,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal(values[:portal][:host], configmap["data"]["host"])
       end
+
       it 'path  can be overridden' do
         values = {
           portal: {
@@ -127,6 +135,7 @@ class Test < ChartTest
         assert_equal(values[:portal][:path], configmap["data"]["path"])
       end
     end
+
     describe 'configmap::portal-nodePort' do
       it 'nodePort host defaults to "$node_ip"' do
         values = {
@@ -147,6 +156,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("$node_ip", configmap["data"]["host"])
       end
+
       it 'nodePort port defaults to the nodePort' do
         values = {
           portal: {
@@ -166,6 +176,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("666", configmap["data"]["port"])
       end
+
       it 'uses nodeport port protocol as protocol (HTTPS)' do
         values = {
           portal: {
@@ -186,6 +197,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
       end
+
       it 'uses nodeport port protocol as protocol (HTTP)' do
         values = {
           portal: {
@@ -207,6 +219,7 @@ class Test < ChartTest
         assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
       end
     end
+
     describe 'configmap::portal-Ingress' do
       it 'uses ingress host' do
         values = {
@@ -234,6 +247,7 @@ class Test < ChartTest
         configmap = chart.resources(kind: "ConfigMap").first
         assert_equal("test.domain", configmap["data"]["host"])
       end
+
       it 'uses ingress path' do
         values = {
           portal: {

--- a/test/stable/common/pvc_spec.rb
+++ b/test/stable/common/pvc_spec.rb
@@ -62,6 +62,21 @@ class Test < ChartTest
         assert_equal('test', pvc["spec"]["storageClassName"])
       end
 
+      it 'can generate TrueNAS SCALE zfs storageClass' do
+        values = {
+          persistence: {
+            config: {
+              enabled: true,
+              storageClass: "SCALE-ZFS"
+            }
+          }
+        }
+        chart.value values
+        pvc = chart.resources(kind: "PersistentVolumeClaim").find{ |s| s["metadata"]["name"] == "common-test-config" }
+        refute_nil(pvc)
+        assert_equal('ix-storage-class-common-test', pvc["spec"]["storageClassName"])
+      end
+
       it 'storageClass can be set to an empty value' do
         values = {
           persistence: {

--- a/test/stable/common/service_spec.rb
+++ b/test/stable/common/service_spec.rb
@@ -82,7 +82,7 @@ class Test < ChartTest
         assert_match("Our charts do not support named ports for targetPort. (port name #{default_name}, targetPort #{values[:service][:port][:targetPort]})", exception.message)
       end
 
-      it 'protocol is TCP be default' do
+      it 'protocol defaults to TCP' do
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(service)
         assert_equal("TCP", service["spec"]["ports"].first["protocol"])
@@ -92,6 +92,7 @@ class Test < ChartTest
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal("TCP", mainContainer["ports"].first["protocol"])
       end
+
       it 'protocol is TCP when set to TCP explicitly' do
         values = {
           service: {
@@ -110,6 +111,7 @@ class Test < ChartTest
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal("TCP", mainContainer["ports"].first["protocol"])
       end
+
       it 'protocol is TCP when set to HTTP explicitly' do
         values = {
           service: {
@@ -128,6 +130,7 @@ class Test < ChartTest
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal("TCP", mainContainer["ports"].first["protocol"])
       end
+
       it 'protocol is TCP when set to HTTPS explicitly' do
         values = {
           service: {
@@ -146,6 +149,7 @@ class Test < ChartTest
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal("TCP", mainContainer["ports"].first["protocol"])
       end
+
       it 'protocol is UDP when set to UDP explicitly' do
         values = {
           service: {

--- a/test/stable/common/service_spec.rb
+++ b/test/stable/common/service_spec.rb
@@ -81,6 +81,89 @@ class Test < ChartTest
         end
         assert_match("Our charts do not support named ports for targetPort. (port name #{default_name}, targetPort #{values[:service][:port][:targetPort]})", exception.message)
       end
+
+      it 'protocol is TCP be default' do
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("TCP", service["spec"]["ports"].first["protocol"])
+
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal("TCP", mainContainer["ports"].first["protocol"])
+      end
+      it 'protocol is TCP when set to TCP explicitly' do
+        values = {
+          service: {
+            port: {
+              protocol: 'TCP'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("TCP", service["spec"]["ports"].first["protocol"])
+
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal("TCP", mainContainer["ports"].first["protocol"])
+      end
+      it 'protocol is TCP when set to HTTP explicitly' do
+        values = {
+          service: {
+            port: {
+              protocol: 'HTTP'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("TCP", service["spec"]["ports"].first["protocol"])
+
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal("TCP", mainContainer["ports"].first["protocol"])
+      end
+      it 'protocol is TCP when set to HTTPS explicitly' do
+        values = {
+          service: {
+            port: {
+              protocol: 'HTTPS'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("TCP", service["spec"]["ports"].first["protocol"])
+
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal("TCP", mainContainer["ports"].first["protocol"])
+      end
+      it 'protocol is UDP when set to UDP explicitly' do
+        values = {
+          service: {
+            port: {
+              protocol: 'UDP'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("UDP", service["spec"]["ports"].first["protocol"])
+
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal("UDP", mainContainer["ports"].first["protocol"])
+      end
     end
   end
 end


### PR DESCRIPTION
**Description of the change**

This PR adds "HTTP" and "HTTPS" port protocols.
These protocol settings then get used for:
- A more precise connection url in the post-install notes
- Consume the settings to create a config map with connection settings for the SCALE portal button

In the service and container definition, `HTTP` and `HTTPS` is simply changed into `TCP`

Also added in this PR is an option to set storageClass to "SCALE-ZFS" which automatically generates the right storageClassName for TrueNAS SCALE

In addition all these settings are completely covered with new unittests, to prevent this from breaking by accident.

**Benefits**

- Notes now contain the right connection protocol, which helps for non-http charts like Unifi-Controller
- SCALE users can now (dynamically) set have the portal button point to the right url
- SCALE users can now use PVC storage correctly

**Possible drawbacks**

- If users change an app from HTTP to HTTPS internally, it wouldn't get automatically detected.
_But that's also currently the case_

- The portal button configMap can not be used on most non-SCALE deployments, as its name is not dynamic but fixed to be "portal" 
_dynamic names cannot be used for the configmap because SCALE has no ability to use a dynamic name for it, however: no other system should need to use the configmap. In case anyone does really want to use it outside of scale, I've documented the workaround in values.yaml: making sure every chart is deployed in it's own namespace._

<!-- Describe any known limitations with your change -->

**Applicable issues**

None

**Additional information**

- The new way of including http/https information in the port type, is also quite handy to use in the ingress configuration. However, I plan some significant work on Ingress as a part 3, so this isn't included in this part 2, as it would overcomplicate review.

- These porting PR's are designed around preventing breaking changes and minimize the amount of "SCALE only" code. In some cases, however, there might be a need for a SCALE-ONLY configmap or secret for the UI.

- A side goal is to also provide improvements for non-scale users.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
