### PR TITLE
[Draft] Use ingress name to fetch Service information

### DIFF
--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -5,16 +5,22 @@ within the common library.
 {{- define "common.classes.ingress" -}}
 {{- $ingressName := include "common.names.fullname" . -}}
 {{- $values := .Values.ingress -}}
+
 {{- if hasKey . "ObjectValues" -}}
   {{- with .ObjectValues.ingress -}}
     {{- $values = . -}}
   {{- end -}}
 {{ end -}}
+
+
 {{- if hasKey $values "nameSuffix" -}}
   {{- $ingressName = printf "%v-%v" $ingressName $values.nameSuffix -}}
 {{ end -}}
+
+
 {{- $svcName := $values.serviceName | default (include "common.names.fullname" .) -}}
 {{- $svcPort := $values.servicePort | default $.Values.service.port.port -}}
+
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -5,10 +5,8 @@ within the common library.
 {{- define "common.classes.ingress" -}}
 {{- $ingressName := include "common.names.fullname" . -}}
 {{- $values := .Values.ingress -}}
-
 {{- $svcName := include "common.names.fullname" . -}}
 {{- $svcPort := 80 -}}
-{{- $portProtocol := "" -}}
 {{- $ingressService := $.Values.service -}}
 
 {{- if hasKey . "ObjectValues" -}}
@@ -19,23 +17,14 @@ within the common library.
 
 
 {{/*
-This code portion, generates default service settings based on the name of the ingress.
-It is complicated because it needs to fetch service information based on a decision tree.
-
-It does a few things:
-- It adds the "nameSuffix" to the name of the ingress, if available
+Set ingressName
+Set svcPort and svcName defaults based on ingress and service names
 - It tries to find a service with the same name as the ingress
-- If a service with the same name as the ingress exists (and is enabled), it tries to use it's port, protocol and name
+- If a service with the same name as the ingress exists (and is enabled), it tries to use it's port and name
 - If such a service does not exist, or is disabled, it tries to use the main service
 - If no service with the same name AND no main service are found, it uses:
    default port 80
    default fullname as name
-   protocol ""
-
-All of these settings can also be overridden from the ingress using the following settings in values.yaml:
-- serviceName (sets the name used as backend service)
-- servicePort (sets the poprt used by the backend service)
-- portProtocol (sets the protocol used by the backend service)
 */}}
 {{- if hasKey $values "nameSuffix" -}}
   {{- $ingressName = printf "%v-%v" $ingressName $values.nameSuffix -}}
@@ -44,19 +33,14 @@ All of these settings can also be overridden from the ingress using the followin
     {{- if $ingressService.enabled }}
       {{- $svcName := $values.serviceName | default (printf "%v-%v" $svcName $values.nameSuffix | quote ) -}}
       {{- $svcPort = $values.servicePort | default $ingressService.port.port -}}
-      {{- $portProtocol = $ingressService.port.protocol | default "" }}
     {{- else if $.Values.service.main.enabled }}
       {{- $svcPort = $values.servicePort | $.Values.service.main.port.port -}}
-      {{- $portProtocol = $.Values.service.main.port.protocol | default "" -}}
     {{ end -}}
   {{ end -}}
 {{- else if and ( $.Values.service.main.enabled ) ( not $values.servicePort ) }}
   {{- $svcPort = $values.servicePort | $.Values.service.main.port.port -}}
-  {{- $portProtocol =  $.Values.service.main.port.protocol | default "" -}}
 {{ end -}}
-{{- if $values.portProtocol }}
-  {{- $portProtocol = $values.portProtocol -}}
-{{- end }}
+
 
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress


### PR DESCRIPTION
**Description of the change**

This is an early draft that requires #32 and #33 to be merged first.

We currently use the service information provided with the ingress definition in Values.yaml first, this will not change.

What will change is the defaults that get used if no service information is provided with the ingress:
Instead of always fetching the service information from the main service, this PR:
- Looks if there is an enabled service with the same name as the ingress (and uses it's information)
- Looks if there is an enabled main service (and uses it's information)
- Reverts to some sane defaults (port 80, fullname as servicename)

In that specific order.


<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- Makes it easier to create specific ingresses for specific services

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- Adds a rather complicated piece of code to the Ingress

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
