### PR TITLE
[Common] Set Traefik service-protocol annotation based on port protocol

### DIFF
--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -248,6 +248,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Horizontal Pod Autoscaler`
 - Can now use "HTTP" or "HTTPS" as port protocol (which use TCP under-the-hood)
+- Setting the port protocol to "HTTPS" adds traefik annotation to use https towards the backend service
 - Add option to automatically generate a configmap for use with the TrueNAS SCALE UI portal-button
 - Added option to use TrueNAS SCALE default storageClass by using `SCALE-ZFS` storageClass
 - It is now possible to set the `serviceName` and `servicePort` per Ingress path

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -23,8 +23,11 @@ metadata:
   {{- if $values.labels }}
     {{ toYaml $values.labels | nindent 4 }}
   {{- end }}
-  {{- with $values.annotations }}
   annotations:
+  {{- if eq ( $values.port.protocol | default "" ) "HTTPS" }}
+    traefik.ingress.kubernetes.io/service.serversscheme: https
+  {{- end }}
+  {{- with $values.annotations }}
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -156,6 +156,7 @@ service:
   enabled: true
   type: ClusterIP
   ## Specify the default port information
+  ## It is adviced not to mix different port protocols on the same service
   port:
     port:
     ## name defaults to http

--- a/test/stable/common/service_spec.rb
+++ b/test/stable/common/service_spec.rb
@@ -168,6 +168,38 @@ class Test < ChartTest
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal("UDP", mainContainer["ports"].first["protocol"])
       end
+
+      it 'No annotations get set by default' do
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_nil(service["metadata"]["annotations"])
+      end
+      it 'TCP port protocol does not set annotations' do
+        values = {
+          service: {
+            port: {
+              protocol: 'TCP'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_nil(service["metadata"]["annotations"])
+      end
+      it 'HTTPS port protocol sets traefik HTTPS annotation' do
+        values = {
+          service: {
+            port: {
+              protocol: 'HTTPS'
+            }
+          }
+        }
+        chart.value values
+        service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(service)
+        assert_equal("https", service["metadata"]["annotations"]["traefik.ingress.kubernetes.io/service.serversscheme"])
+      end
     end
   end
 end


### PR DESCRIPTION
**Description of the change**

We already have the ability to flag the main port of a service as using HTTPS.

This PR uses the protocol used by the main port of a service, to set the annotation traefik requires to correctly detect the backendservice as using HTTPS.

This is due to the fact traefik by default only detects https backends when using a specific lists of common default ports. Which may cause confusion when people want to run charts with traefik.

This annotation is also rather simple to add and only causes issues in very niche cases, which shouldn't happen and are easily preventable.

It's also helps a lot setting this for SCALE compatibiltiy, because the UI codes gets insanely cluttered when we manually need to st these on a case-by-case bassis

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- Users have an easier time using the charts with Traefik
- Helps with SCALE compatibility/clean-code

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- May cause issues when people mix-and-match different port protocols on the same service and want to pass both through traefik (which isn't best-practice anyway and has caused problems in the past, so is quite ill-adviced)

May cause issues in one specific case where:
- The user wants to use nodePort AND ingress via traefik
- Does not want to run a second traefik instance
- Want to use App-buildin https on the nodePort connection
- Does not want to disable the strict checking of backend certificates on traefik

This is a VERY niche usecase and most of these issues are mostly cause by the user being unflexible, because if any of the above requirements are removed it wouldn't be an issue.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

- Unittests for the feature are included.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
Version already bumped on common-next