### PR TITLE
[common] Add support for TrueNAS SCALE integrated certificates

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.5.0
+version: 2.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -242,6 +242,12 @@ All notable changes to this application Helm chart will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.6.0]
+
+#### Added
+
+- Added support for selecting TrueNAS SCALE integrated certificates using the GUI
+
 ### [2.5.0]
 
 #### Added

--- a/charts/stable/common/templates/_ingress.tpl
+++ b/charts/stable/common/templates/_ingress.tpl
@@ -11,6 +11,12 @@ of the main Ingress and any additionalIngresses.
     {{- $_ := set . "ObjectValues" (dict "ingress" $ingressValues) -}}
     {{- include "common.classes.ingress" . }}
 
+    {{- if $ingressValues.scaleCert -}}
+    {{- $_ := set $ "ObjectValues" (dict "certHolder" $ingressValues) -}}
+    {{- print ("---") | nindent 0 -}}
+    {{- include "common.scale.cert.secret" $ -}}
+    {{ end -}}
+
     {{- /* Generate additional ingresses as required */ -}}
     {{- range $index, $extraIngress := .Values.ingress.additionalIngresses }}
       {{- if $extraIngress.enabled -}}
@@ -21,6 +27,12 @@ of the main Ingress and any additionalIngresses.
         {{ end -}}
         {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
         {{- include "common.classes.ingress" $ -}}
+
+        {{- if $ingressValues.scaleCert -}}
+        {{- $_ := set $ "ObjectValues" (dict "certHolder" $ingressValues) -}}
+        {{- print ("---") | nindent 0 -}}
+        {{- include "common.scale.cert.secret" $ -}}
+        {{ end -}}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -41,8 +41,10 @@ spec:
         {{- range .hostsTpl }}
         - {{ tpl . $ | quote }}
         {{- end }}
-      {{- if or .secretNameTpl .secretName }}
-      {{- if .secretNameTpl }}
+      {{- if or .secretNameTpl .secretName .scaleCert }}
+      {{- if .scaleCert }}
+      secretName: {{ ( printf "%v-%v" $ingressName "scalecert" ) }}
+      {{- else if .secretNameTpl }}
       secretName: {{ tpl .secretNameTpl $ | quote}}
       {{- else }}
       secretName: {{ .secretName }}

--- a/charts/stable/common/templates/lib/scale/_certHelpers.tpl
+++ b/charts/stable/common/templates/lib/scale/_certHelpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Retrieve true/false if certificate is configured
+*/}}
+{{- define "common.scale.cert.available" -}}
+{{- if .ObjectValues.certHolder.scaleCert -}}
+{{- $values := (. | mustDeepCopy) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.scaleCert) -}}
+{{- template "common.scale.cert_present" $values -}}
+{{- else -}}
+{{- false -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Retrieve public key of certificate
+*/}}
+{{- define "common.scale.cert.publicKey" -}}
+{{- $values := (. | mustDeepCopy) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.scaleCert "publicKey" true) -}}
+{{ include "common.scale.cert" $values }}
+{{- end -}}
+
+
+{{/*
+Retrieve private key of certificate
+*/}}
+{{- define "common.scale.cert.privateKey" -}}
+{{- $values := (. | mustDeepCopy) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.scaleCert) -}}
+{{ include "common.scale.cert" $values }}
+{{- end -}}

--- a/charts/stable/common/templates/lib/scale/_certSecret.tpl
+++ b/charts/stable/common/templates/lib/scale/_certSecret.tpl
@@ -1,0 +1,26 @@
+{{- define "common.scale.cert.secret" -}}
+
+{{- $secretName := include "common.names.fullname" . -}}
+
+{{- if .ObjectValues.certHolder -}}
+  {{- if hasKey .ObjectValues.certHolder "nameSuffix" -}}
+    {{- $secretName = ( printf "%v-%v-%v" $secretName .ObjectValues.certHolder.nameSuffix "scalecert" ) -}}
+  {{ end -}}
+  {{- $secretName = ( printf "%v-%v" $secretName "scalecert" ) -}}
+{{ else }}
+  {{- $_ := set $ "ObjectValues" (dict "certHolder" .Values) -}}
+  {{- $secretName = ( printf "%v-%v" $secretName "scalecert" ) -}}
+{{ end -}}
+
+{{- if eq (include "common.scale.cert.available" $ ) "true" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{ include "common.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ (include "common.scale.cert.publicKey" $ ) | toString | b64enc | quote }}
+  tls.key: {{ (include "common.scale.cert.privateKey" $ ) | toString | b64enc | quote }}
+{{- end -}}
+{{- end -}}

--- a/charts/stable/common/templates/lib/scale/_certs.tpl
+++ b/charts/stable/common/templates/lib/scale/_certs.tpl
@@ -1,0 +1,24 @@
+{{/*
+Retrieve true/false if certificate is available in ixCertificates
+*/}}
+{{- define "common.scale.cert_present" -}}
+{{- $values := . -}}
+{{- hasKey $values.Values.ixCertificates ($values.commonCertOptions.certKeyName | toString) -}}
+{{- end -}}
+
+
+{{/*
+Retrieve certificate from variable name
+*/}}
+{{- define "common.scale.cert" -}}
+{{- $values := . -}}
+{{- $certKey := ($values.commonCertOptions.certKeyName | toString) -}}
+{{- if hasKey $values.Values.ixCertificates $certKey -}}
+{{- $cert := get $values.Values.ixCertificates $certKey -}}
+{{- if $values.commonCertOptions.publicKey -}}
+{{ $cert.certificate }}
+{{- else -}}
+{{ $cert.privatekey }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -217,7 +217,12 @@ ingress:
           # pathTpl: '{{ include "common.names.fullname" . }}'
           ## Ignored if not kubeVersion >= 1.14-0
           pathType: Prefix
+  ## Gets set by TrueNAS SCALE when selecting an integrated certificate
+  # scaleCert: 1
   tls: []
+  ## Can be used to enable using the TrueNAS SCALE certificate selected above
+  #  - scaleCert: true
+  ## Use normal secret
   #  - secretName: chart-example-tls
   ## Or if you need a dynamic secretname
   #  - secretNameTpl: '{{ include "common.names.fullname" . }}-ingress'

--- a/test/stable/common/scale_cert_spec.rb
+++ b/test/stable/common/scale_cert_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+class Test < ChartTest
+  @@chart = Chart.new('helper-charts/common-test')
+  describe @@chart.name do
+    describe 'scaleCertificate' do
+      it 'disabled by default' do
+        values = {
+          ingress: {
+            enabled: true
+          }
+        }
+        chart.value values
+        assert_nil(resource('Secret'))
+      end
+      it 'can be enabled and selected' do
+        values = {
+            "ixCertificateAuthorities": {},
+            "ixCertificates": {
+              "1": {
+                "CA_type_existing": false,
+                "CA_type_intermediate": false,
+                "CA_type_internal": false,
+                "CSR": "",
+                "DN": "/C=US/O=iXsystems/CN=localhost/emailAddress=info@ixsystems.com/ST=Tennessee/L=Maryville/subjectAltName=DNS:localhost",
+                "cert_type": "CERTIFICATE",
+                "cert_type_CSR": false,
+                "cert_type_existing": true,
+                "cert_type_internal": false,
+                "certificate": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n",
+                "certificate_path": "/etc/certificates/freenas_default.crt",
+                "chain": false,
+                "chain_list": [
+                  "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n"
+                ],
+                "city": "Maryville",
+                "common": "localhost",
+                "country": "US",
+                "csr_path": "/etc/certificates/freenas_default.csr",
+                "digest_algorithm": "SHA256",
+                "email": "info@ixsystems.com",
+                "extensions": {
+                  "ExtendedKeyUsage": "TLS Web Server Authentication",
+                  "SubjectAltName": "DNS:localhost"
+                },
+                "fingerprint": "9C:5A:1D:1B:E7:9E:0B:89:2B:37:F4:19:83:ED:3C:6B:D8:14:0D:9B",
+                "from": "Fri Sep 25 16:05:38 2020",
+                "id": 1,
+                "internal": "NO",
+                "issuer": "external",
+                "key_length": 2048,
+                "key_type": "RSA",
+                "lifetime": 825,
+                "name": "freenas_default",
+                "organization": "iXsystems",
+                "organizational_unit": "",
+                "parsed": true,
+                "privatekey": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC6aBpYooul/A3q\nBXS3Ee447HySJ95wvH9aUy0N0VER1DhMoT092ek5IWh3h6I/A+pIl0TociSat5MO\nTnqhmYrH6RkIZMY6cZH4fXwIZb4bi8Alh2jL0odU2k/offnh33Md7p+QiGh/G9Sm\nEQTB/o5ihaa+45DzZAVy0jAO4yiCGvKQ/UepReIALG6iWnwm090e26pHfcad5949\nmIakMxE1NpZruH62twT4qKHyuO5EpILlAuprZOlaw39vkLQipWNHbWxd3tmQTVqN\nWo/OrIwraBJqjgjLD0S3P18EHHxKh2OF32n18KpNBtFMVdnHtfMSqEf6TdzKSwWe\nuTcz56Z9AgMBAAECggEARwcb4uIs7BZbBu0FSCyg5TfXT6m5bKOmszg2VqmHho+i\n1DAsMcEyyP4d3E3mWLSZNQfOzfOQVxPUCQOGXsUuyHXdgAFGN0bHJDRMara59a0O\njj5GhEO4JXD6OdCmwpZuOt2OF3iiuKxWHuElOvZQMuJSYzI7LULTgKjufv23lbsf\nxMO/v9yi57c5EGgnQ8siLKOy/FQZapn4Z9qKn+lVyk5gfaKP0pDsvV4d7nGYMDD2\nYijfkSyNecApFdtWiLE5zLUlvF6oNj8o66z3YrVNKrCPzhA/5Rkkwwk32SNxvKU3\nVZFSNPeOZ60BicxYcWO+b2aAa0WF+uazJAZ4q52gUQKBgQDu88R+0wm76secYkzE\nQglteLNZKFcvth0kI5xH42Hmk9IXkGimFoDJCIrLAuopyGnfNmqmh2is3QUMUPdR\n/wDLnKc4MCezEidNoD2RBC+bzM1hB9oye/b5sOZUDFXSa0k4XSLu1UEuy1yWhkuS\n6JjY1KQfc4FN0K0Fjqqo7UCTCwKBgQDHtKQh/NvMJ2ok4YW+/QAsus4mEK9eCyUy\nOuyDszQYrGvjkS7STKJVNxGLhWb0XKSIAxMZ66b1MwOt+71h7xNn6pcancfVdK7F\n1Xl5J+76SwbXSgQwTZuoMDxPIvZn7v/2ep5Ni/BcOhMcPIcobWb/OmXrFN1brBvo\nlFNQyWWhlwKBgFDAyPMjVvLO0U6kWdUpjA4W8GV9IJnbLdX8wt/4lClcY2/bOcKH\ncFaAMIeTIJemR0FMHpbQxCtHNmGHK03mo9orwsdWXtRBmk69jJDpnT1F5VKZWMAe\n7MRNaEmXMZm+8CvALgIQx8qMp2mnUPsA6Ea+9gg6/MPTdeWe5UXZiC0pAoGAGtSt\nPJfBXBNrklruYjORo3DRo5GYThVHQRFjl2orNKltsVxfIwgCw1ortEgPBgOwY0mu\ndkwP2V+qPeTVk+PQAqUk+gF6yLXtiUzeDiYMWHpeB+y81VSH9jfM0oELA/m7T/03\naYnEmE+BI8kKC6dvMBlDeisKdneQJFZRP0hfrC8CgYEAgYIyCGwcydKpe2Nkj0Fz\nKTtCMC/k4DvJfd5Kb9AbmrPUfKgA9Xj4GT6yPG6uBMi8r5etvLCKJ2x2NtN024a8\nQJLATYPrSsaZkE+9zM0j5nYAgbKpxBhlDzDAzn//3ByVzfgJ25S80XhTI2lfbLH/\nU07ssxdZaQCo+WuD82OvNcg=\n-----END PRIVATE KEY-----\n",
+                "privatekey_path": "/etc/certificates/freenas_default.key",
+                "revoked": false,
+                "revoked_date": "",
+                "root_path": "/etc/certificates",
+                "san": [
+                  "DNS:localhost"
+                ],
+                "serial": 1,
+                "signedby": "",
+                "state": "Tennessee",
+                "subject_name_hash": 3193428416,
+                "type": 8,
+                "until": "Thu Dec 29 15:05:38 2022"
+              }
+            },
+          ingress: {
+            enabled: true,
+            scaleCert: 1
+          }
+        }
+        chart.value values
+        refute_nil(resource('Secret'))
+        secret = chart.resources(kind: "Secret").first
+        assert_equal("common-test-scalecert", secret["metadata"]["name"])
+        refute_nil(secret["data"]["tls.crt"])
+        refute_nil(secret["data"]["tls.key"])
+      end
+
+      it 'secret can be used for TLS ingress' do
+        values = {
+            "ixCertificateAuthorities": {},
+            "ixCertificates": {
+              "1": {
+                "CA_type_existing": false,
+                "CA_type_intermediate": false,
+                "CA_type_internal": false,
+                "CSR": "",
+                "DN": "/C=US/O=iXsystems/CN=localhost/emailAddress=info@ixsystems.com/ST=Tennessee/L=Maryville/subjectAltName=DNS:localhost",
+                "cert_type": "CERTIFICATE",
+                "cert_type_CSR": false,
+                "cert_type_existing": true,
+                "cert_type_internal": false,
+                "certificate": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n",
+                "certificate_path": "/etc/certificates/freenas_default.crt",
+                "chain": false,
+                "chain_list": [
+                  "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n"
+                ],
+                "city": "Maryville",
+                "common": "localhost",
+                "country": "US",
+                "csr_path": "/etc/certificates/freenas_default.csr",
+                "digest_algorithm": "SHA256",
+                "email": "info@ixsystems.com",
+                "extensions": {
+                  "ExtendedKeyUsage": "TLS Web Server Authentication",
+                  "SubjectAltName": "DNS:localhost"
+                },
+                "fingerprint": "9C:5A:1D:1B:E7:9E:0B:89:2B:37:F4:19:83:ED:3C:6B:D8:14:0D:9B",
+                "from": "Fri Sep 25 16:05:38 2020",
+                "id": 1,
+                "internal": "NO",
+                "issuer": "external",
+                "key_length": 2048,
+                "key_type": "RSA",
+                "lifetime": 825,
+                "name": "freenas_default",
+                "organization": "iXsystems",
+                "organizational_unit": "",
+                "parsed": true,
+                "privatekey": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC6aBpYooul/A3q\nBXS3Ee447HySJ95wvH9aUy0N0VER1DhMoT092ek5IWh3h6I/A+pIl0TociSat5MO\nTnqhmYrH6RkIZMY6cZH4fXwIZb4bi8Alh2jL0odU2k/offnh33Md7p+QiGh/G9Sm\nEQTB/o5ihaa+45DzZAVy0jAO4yiCGvKQ/UepReIALG6iWnwm090e26pHfcad5949\nmIakMxE1NpZruH62twT4qKHyuO5EpILlAuprZOlaw39vkLQipWNHbWxd3tmQTVqN\nWo/OrIwraBJqjgjLD0S3P18EHHxKh2OF32n18KpNBtFMVdnHtfMSqEf6TdzKSwWe\nuTcz56Z9AgMBAAECggEARwcb4uIs7BZbBu0FSCyg5TfXT6m5bKOmszg2VqmHho+i\n1DAsMcEyyP4d3E3mWLSZNQfOzfOQVxPUCQOGXsUuyHXdgAFGN0bHJDRMara59a0O\njj5GhEO4JXD6OdCmwpZuOt2OF3iiuKxWHuElOvZQMuJSYzI7LULTgKjufv23lbsf\nxMO/v9yi57c5EGgnQ8siLKOy/FQZapn4Z9qKn+lVyk5gfaKP0pDsvV4d7nGYMDD2\nYijfkSyNecApFdtWiLE5zLUlvF6oNj8o66z3YrVNKrCPzhA/5Rkkwwk32SNxvKU3\nVZFSNPeOZ60BicxYcWO+b2aAa0WF+uazJAZ4q52gUQKBgQDu88R+0wm76secYkzE\nQglteLNZKFcvth0kI5xH42Hmk9IXkGimFoDJCIrLAuopyGnfNmqmh2is3QUMUPdR\n/wDLnKc4MCezEidNoD2RBC+bzM1hB9oye/b5sOZUDFXSa0k4XSLu1UEuy1yWhkuS\n6JjY1KQfc4FN0K0Fjqqo7UCTCwKBgQDHtKQh/NvMJ2ok4YW+/QAsus4mEK9eCyUy\nOuyDszQYrGvjkS7STKJVNxGLhWb0XKSIAxMZ66b1MwOt+71h7xNn6pcancfVdK7F\n1Xl5J+76SwbXSgQwTZuoMDxPIvZn7v/2ep5Ni/BcOhMcPIcobWb/OmXrFN1brBvo\nlFNQyWWhlwKBgFDAyPMjVvLO0U6kWdUpjA4W8GV9IJnbLdX8wt/4lClcY2/bOcKH\ncFaAMIeTIJemR0FMHpbQxCtHNmGHK03mo9orwsdWXtRBmk69jJDpnT1F5VKZWMAe\n7MRNaEmXMZm+8CvALgIQx8qMp2mnUPsA6Ea+9gg6/MPTdeWe5UXZiC0pAoGAGtSt\nPJfBXBNrklruYjORo3DRo5GYThVHQRFjl2orNKltsVxfIwgCw1ortEgPBgOwY0mu\ndkwP2V+qPeTVk+PQAqUk+gF6yLXtiUzeDiYMWHpeB+y81VSH9jfM0oELA/m7T/03\naYnEmE+BI8kKC6dvMBlDeisKdneQJFZRP0hfrC8CgYEAgYIyCGwcydKpe2Nkj0Fz\nKTtCMC/k4DvJfd5Kb9AbmrPUfKgA9Xj4GT6yPG6uBMi8r5etvLCKJ2x2NtN024a8\nQJLATYPrSsaZkE+9zM0j5nYAgbKpxBhlDzDAzn//3ByVzfgJ25S80XhTI2lfbLH/\nU07ssxdZaQCo+WuD82OvNcg=\n-----END PRIVATE KEY-----\n",
+                "privatekey_path": "/etc/certificates/freenas_default.key",
+                "revoked": false,
+                "revoked_date": "",
+                "root_path": "/etc/certificates",
+                "san": [
+                  "DNS:localhost"
+                ],
+                "serial": 1,
+                "signedby": "",
+                "state": "Tennessee",
+                "subject_name_hash": 3193428416,
+                "type": 8,
+                "until": "Thu Dec 29 15:05:38 2022"
+              }
+            },
+          ingress: {
+            enabled: true,
+            scaleCert: 1,
+            tls: [
+              {
+                hosts: [ 'hostname' ],
+                scaleCert: true
+              }
+            ]
+          }
+        }
+        chart.value values
+        refute_nil(resource('Secret'))
+        secret = chart.resources(kind: "Secret").first
+        assert_equal("common-test-scalecert", secret["metadata"]["name"])
+        refute_nil(secret["data"]["tls.crt"])
+        refute_nil(secret["data"]["tls.key"])
+
+        ingress = chart.resources(kind: "Ingress").find{ |s| s["metadata"]["name"] == "common-test" }
+        refute_nil(ingress)
+        assert_equal("common-test-scalecert", ingress["spec"]["tls"][0]["secretName"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description of the change**

This is the last big part of the SCALE compatibility patches (besides the breaking restructure).
It adds support to use certificates from the SCALE certificate backend (selected in the GUI) as ingress TLS certificates

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- It allows super easy TLS ingress for SCALE users
- It should be completely ignored for non-scale users

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- A slightly more complicated codebase, although it's mostly seperated into seperate files

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

- Unit-tests are included

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
