### PR TITLE
[common] [Next-Major] cleanly restructured ingresses into dict

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.5.0
+version: 3.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -68,7 +68,8 @@ service:
     port: 1880
 
 ingress:
-  enabled: false
+  main:
+    enabled: false
 
 persistence:
   data:
@@ -175,14 +176,13 @@ helm dependency update
 | fullnameOverride | string | `""` |  |
 | hostAliases | list | `[]` |  |
 | hostNetwork | bool | `false` |  |
-| ingress.additionalIngresses | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
-| ingress.labels | object | `{}` |  |
-| ingress.tls | list | `[]` |  |
+| ingress.main.mainannotations | object | `{}` |  |
+| ingress.main.enabled | bool | `false` |  |
+| ingress.main.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.main.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.main.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| ingress.main.labels | object | `{}` |  |
+| ingress.main.tls | list | `[]` |  |
 | initContainers | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -241,6 +241,13 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.0.0]
+
+#### Changed
+
+- Moved the primary ingress from `ingress` to `ingress.main`
+- Moved the Additional Ingresses from `ingress.additionalIngresses` to `ingress.nameOfAdditionalIngress`
 
 ### [2.5.0]
 

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -37,7 +37,6 @@ Main entrypoint for the common library chart. It will render all underlying temp
   {{ include "common.classes.hpa" . | nindent 0 }}
   {{- print "---" | nindent 0 -}}
   {{ include "common.service" . | nindent 0 }}
-  {{- print "---" | nindent 0 -}}
   {{ include "common.ingress" .  | nindent 0 }}
   {{- if .Values.secret -}}
     {{- print "---" | nindent 0 -}}

--- a/charts/stable/common/templates/_ingress.tpl
+++ b/charts/stable/common/templates/_ingress.tpl
@@ -3,25 +3,19 @@ Renders the Ingress objects required by the chart by returning a concatinated li
 of the main Ingress and any additionalIngresses.
 */}}
 {{- define "common.ingress" -}}
-  {{- if .Values.ingress.enabled -}}
-    {{- $svcPort := .Values.service.port.port -}}
+    {{- /* Generate named ingresses as required */ -}}
+    {{- range $name, $ingress := .Values.ingress }}
+      {{- if $ingress.enabled -}}
+        {{- print ("---\n") | nindent 0 -}}
+        {{- $ingressValues := $ingress -}}
 
-    {{- /* Generate primary ingress */ -}}
-    {{- $ingressValues := .Values.ingress -}}
-    {{- $_ := set . "ObjectValues" (dict "ingress" $ingressValues) -}}
-    {{- include "common.classes.ingress" . }}
-
-    {{- /* Generate additional ingresses as required */ -}}
-    {{- range $index, $extraIngress := .Values.ingress.additionalIngresses }}
-      {{- if $extraIngress.enabled -}}
-        {{- print ("---") | nindent 0 -}}
-        {{- $ingressValues := $extraIngress -}}
-        {{- if not $ingressValues.nameSuffix -}}
-          {{- $_ := set $ingressValues "nameSuffix" $index -}}
+        {{/* set defaults */}}
+        {{- if and (not $ingressValues.nameSuffix) ( ne $name "main" ) -}}
+          {{- $_ := set $ingressValues "nameSuffix" $name -}}
         {{ end -}}
+
         {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
-        {{- include "common.classes.ingress" $ -}}
+        {{- include "common.classes.ingress" $ }}
       {{- end }}
     {{- end }}
-  {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/_notes.tpl
+++ b/charts/stable/common/templates/_notes.tpl
@@ -8,10 +8,11 @@ Default NOTES.txt content.
 {{- if eq $svcProtocol "HTTPS" }}
 {{- $prefix = "https" }}
 {{- end }}
+{{- $ingress := false }}
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{- if .hostTpl }}{{ tpl .hostTpl $ }}{{ else }}{{ .host }}{{ end }}{{ (first .paths).path }}
+{{- if .Values.ingress.main.enabled }}
+{{- range .Values.ingress.main.hosts }}
+  http{{ if $.Values.ingress.main.tls }}s{{ end }}://{{- if .hostTpl }}{{ tpl .hostTpl $ }}{{ else }}{{ .host }}{{ end }}{{ (first .paths).path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})

--- a/charts/stable/common/templates/classes/_portal.tpl
+++ b/charts/stable/common/templates/classes/_portal.tpl
@@ -8,9 +8,9 @@
 {{- $portProtocol := "" }}
 {{- $path := "/" }}
 
-{{- if hasKey .Values "ingress" }}
-  {{- if .Values.ingress.enabled }}
-    {{- range .Values.ingress.hosts }}
+{{- if hasKey .Values.ingress "main" }}
+  {{- if .Values.ingress.main.enabled }}
+    {{- range .Values.ingress.main.hosts }}
     {{- if .hostTpl }}
     {{ $host = ( tpl .hostTpl $ ) }}
     {{- else if .host }}
@@ -39,7 +39,7 @@
 {{- if and ( $portProtocol ) ( eq $host "$node_ip" ) }}
   {{- $protocol = $portProtocol }}
 {{- else if and ( ne $host "$node_ip" ) }}
-  {{- if $.Values.ingress.tls }}
+  {{- if $.Values.ingress.main.tls }}
     {{- $protocol = "https" }}
   {{- end }}
 {{- end }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -201,34 +201,33 @@ service:
   #   labels: {}
 
 ingress:
-  enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  labels: {}
-  # ingressClassName: "nginx"
-  hosts:
-    - host: chart-example.local
-      ## Or a tpl that is evaluated
-      # hostTpl: '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
-      paths:
-        - path: /
-          ## Or a tpl that is evaluated
-          # pathTpl: '{{ include "common.names.fullname" . }}'
-          ## Ignored if not kubeVersion >= 1.14-0
-          pathType: Prefix
-  tls: []
-  #  - secretName: chart-example-tls
-  ## Or if you need a dynamic secretname
-  #  - secretNameTpl: '{{ include "common.names.fullname" . }}-ingress'
-  #    hosts:
-  #      - chart-example.local
-  ## Or a tpl that is evaluated
-  #    hostsTpl:
-  #      - '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
-  additionalIngresses: []
-  # - enabled: false
-  #   nameSuffix: "api"
+  main:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    labels: {}
+    # ingressClassName: "nginx"
+    hosts:
+      - host: chart-example.local
+        ## Or a tpl that is evaluated
+        # hostTpl: '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
+        paths:
+          - path: /
+            ## Or a tpl that is evaluated
+            # pathTpl: '{{ include "common.names.fullname" . }}'
+            ## Ignored if not kubeVersion >= 1.14-0
+            pathType: Prefix
+    tls: []
+    #  - secretName: chart-example-tls
+    ## Or if you need a dynamic secretname
+    #  - secretNameTpl: '{{ include "common.names.fullname" . }}-ingress'
+    #    hosts:
+    #      - chart-example.local
+    ## Or a tpl that is evaluated
+    #    hostsTpl:
+    #      - '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
+  # additionalIngress:
   #   annotations: {}
   #   # kubernetes.io/ingress.class: nginx
   #   # kubernetes.io/tls-acme: "true"

--- a/helper-charts/common-test/ci/basic-values.yaml
+++ b/helper-charts/common-test/ci/basic-values.yaml
@@ -8,7 +8,8 @@ service:
     port: 8080
 
 ingress:
-  enabled: true
+  main:
+    enabled: true
 
 probes:
   liveness:

--- a/helper-charts/common-test/ci/codeserver-values.yaml
+++ b/helper-charts/common-test/ci/codeserver-values.yaml
@@ -8,7 +8,8 @@ service:
     port: 8080
 
 ingress:
-  enabled: true
+  main:
+    enabled: true
 
 persistence:
   config:

--- a/helper-charts/common-test/values.yaml
+++ b/helper-charts/common-test/values.yaml
@@ -8,4 +8,5 @@ service:
     port: 8080
 
 ingress:
-  enabled: true
+  main:
+    enabled: true

--- a/test/stable/common/job_permissions_spec.rb
+++ b/test/stable/common/job_permissions_spec.rb
@@ -5,9 +5,8 @@ class Test < ChartTest
   @@chart = Chart.new('helper-charts/common-test')
 
   describe @@chart.name do
-
     describe 'job::permissions' do
-      it 'does not exist by default' do
+      it 'no job exists by default' do
         job = chart.resources(kind: "Job").first
         assert_nil(job)
       end

--- a/test/stable/common/portal_spec.rb
+++ b/test/stable/common/portal_spec.rb
@@ -5,15 +5,13 @@ class Test < ChartTest
   @@chart = Chart.new('helper-charts/common-test')
 
   describe @@chart.name do
-    describe 'configmap::general' do
-      it 'does not exist by default' do
+    describe 'configmap::portal-defaults' do
+      it 'no configmap exists by default' do
         configmap = chart.resources(kind: "ConfigMap").first
         assert_nil(configmap)
       end
-    end
 
-    describe 'configmap::portal-defaults' do
-      it 'can be enabled' do
+      it 'creates configmap whe enabled' do
         values = {
           portal: {
             enabled: true
@@ -41,7 +39,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -55,7 +55,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -69,7 +71,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -83,7 +87,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -112,7 +118,9 @@ class Test < ChartTest
             host: "test.host"
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -127,7 +135,9 @@ class Test < ChartTest
             path: "/path"
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           }
         }
         chart.value values
@@ -143,7 +153,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           },
           service: {
             type: "NodePort",
@@ -163,7 +175,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           },
           service: {
             type: "NodePort",
@@ -183,7 +197,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           },
           service: {
             type: "NodePort",
@@ -204,7 +220,9 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: false
+            main: {
+              enabled: false
+            }
           },
           service: {
             type: "NodePort",
@@ -227,19 +245,21 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: true,
-            hosts: [
-              {
-                host: "test.domain",
-                paths:
-                [
-                  {
-                    path: "/test"
-                  }
-                ]
+            main: {
+              enabled: true,
+              hosts: [
+                {
+                  host: "test.domain",
+                  paths:
+                  [
+                    {
+                      path: "/test"
+                    }
+                  ]
 
-              }
-            ]
+                }
+              ]
+            }
           }
         }
         chart.value values
@@ -254,19 +274,21 @@ class Test < ChartTest
             enabled: true
           },
           ingress: {
-            enabled: true,
-            hosts: [
-              {
-                host: "test.domain",
-                paths:
-                [
-                  {
-                    path: "/test"
-                  }
-                ]
+            main: {
+              enabled: true,
+              hosts: [
+                {
+                  host: "test.domain",
+                  paths:
+                  [
+                    {
+                      path: "/test"
+                    }
+                  ]
 
-              }
-            ]
+                }
+              ]
+            }
           }
         }
         chart.value values


### PR DESCRIPTION
**Description of the change**

part one of reworking the common chart for next major.
This PR: Ingress

Ingresses and additionalIngresses are now dicts under .Values.Ingress
Where the main ingress is defined with "main" (which may be used for future additions, NOTES and/or SCALE portals)

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- A simpler codebase (less code)
- Less nesting
- Clearer for users that all ingresses (additional or not) are mostly the same thing "under the hood"
- Future: easier linking of ingresses and Services

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- Breaking change
- Users need to remember the primary ingress is defined as .Values.ingress.main

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

- Needs to go into a new "Next Major"  branch instead. @bjw-s 
- Or we just go ham and go next-major directly including current next-minor

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
