### PR TITLE
[common] [Next-Major] cleanly restructured Services into dict

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.5.0
+version: 3.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -78,11 +78,12 @@ persistence:
     mountPath: /data
 ```
 
-If not using a service, set the `service.enabled` to `false`.
+If not using a service, set `service.main.enabled` to `false`.
 ```yaml
 ...
 service:
-  enabled: false
+  main:
+    enabled: false
 ...
 ```
 
@@ -218,16 +219,15 @@ helm dependency update
 | resources | object | `{}` |  |
 | secret | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.additionalPorts | list | `[]` |  |
-| service.additionalServices | list | `[]` |  |
-| service.annotations | object | `{}` |  |
-| service.enabled | bool | `true` |  |
-| service.labels | object | `{}` |  |
-| service.port.name | string | `nil` |  |
-| service.port.port | string | `nil` |  |
-| service.port.protocol | string | `"TCP"` |  |
-| service.port.targetPort | string | `nil` |  |
-| service.type | string | `"ClusterIP"` |  |
+| service.main.additionalPorts | list | `[]` |  |
+| service.main.annotations | object | `{}` |  |
+| service.main.enabled | bool | `true` |  |
+| service.main.labels | object | `{}` |  |
+| service.main.port.name | string | `nil` |  |
+| service.main.port.port | string | `nil` |  |
+| service.main.port.protocol | string | `"TCP"` |  |
+| service.main.port.targetPort | string | `nil` |  |
+| service.main.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |
@@ -241,6 +241,13 @@ All notable changes to this application Helm chart will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [3.0.0]
+
+#### Changed
+
+- Main/Default service, is now a sub-dict named `main` under `service` in Values.yaml
+- `additionalServices` are now directly placed as dicts under `service` in Values.yaml
 
 ### [2.5.0]
 

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -35,7 +35,6 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{- include "common.statefulset" . | nindent 0 }}
   {{- end -}}
   {{ include "common.classes.hpa" . | nindent 0 }}
-  {{- print "---" | nindent 0 -}}
   {{ include "common.service" . | nindent 0 }}
   {{- print "---" | nindent 0 -}}
   {{ include "common.ingress" .  | nindent 0 }}

--- a/charts/stable/common/templates/_ingress.tpl
+++ b/charts/stable/common/templates/_ingress.tpl
@@ -4,8 +4,6 @@ of the main Ingress and any additionalIngresses.
 */}}
 {{- define "common.ingress" -}}
   {{- if .Values.ingress.enabled -}}
-    {{- $svcPort := .Values.service.port.port -}}
-
     {{- /* Generate primary ingress */ -}}
     {{- $ingressValues := .Values.ingress -}}
     {{- $_ := set . "ObjectValues" (dict "ingress" $ingressValues) -}}

--- a/charts/stable/common/templates/_notes.tpl
+++ b/charts/stable/common/templates/_notes.tpl
@@ -2,8 +2,9 @@
 Default NOTES.txt content.
 */}}
 {{- define "common.notes.defaultNotes" -}}
-{{- $svcPort := .Values.service.port.port -}}
-{{- $svcProtocol := .Values.service.port.protocol -}}
+{{- $svc := index .Values.services (keys .Values.services | first) -}}
+{{- $svcPort := $svc.port.port -}}
+{{- $svcProtocol := $svc.port.protocol -}}
 {{- $prefix := "http" -}}
 {{- if eq $svcProtocol "HTTPS" }}
 {{- $prefix = "https" }}
@@ -13,16 +14,16 @@ Default NOTES.txt content.
 {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{- if .hostTpl }}{{ tpl .hostTpl $ }}{{ else }}{{ .host }}{{ end }}{{ (first .paths).path }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" $svc.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo {{ $prefix }}://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" $svc.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ include "common.names.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo {{ $prefix }}://$SERVICE_IP:{{ $svcPort }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+{{- else if contains "ClusterIP" $svc.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit {{ $prefix }}://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ $svcPort }}

--- a/charts/stable/common/templates/_service.tpl
+++ b/charts/stable/common/templates/_service.tpl
@@ -1,23 +1,21 @@
 {{/*
 Renders the Service objects required by the chart by returning a concatinated list
-of the main Service and any additionalServices.
+of the main Service and any additionalservice.
 */}}
 {{- define "common.service" -}}
-  {{- if .Values.service.enabled -}}
-    {{- /* Generate primary service */ -}}
-    {{- include "common.classes.service" . }}
+  {{- if .Values.services -}}
+    {{- range $name, $service := .Values.services }}
+      {{- if $service.enabled -}}
+        {{- print ("---\n") | nindent 0 -}}
+        {{- $serviceValues := $service -}}
 
-    {{- /* Generate additional services as required */ -}}
-    {{- range $index, $extraService := .Values.service.additionalServices }}
-      {{- if $extraService.enabled -}}
-        {{- print ("---") | nindent 0 -}}
-        {{- $serviceValues := $extraService -}}
-        {{- if not $serviceValues.nameSuffix -}}
-          {{- $_ := set $serviceValues "nameSuffix" $index -}}
+        {{- if $serviceValues.nameSuffix -}}
+          {{- $_ := set $serviceValues "nameSuffix" $name -}}
         {{ end -}}
+
         {{- $_ := set $ "ObjectValues" (dict "service" $serviceValues) -}}
         {{- include "common.classes.service" $ -}}
-      {{- end }}
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -5,16 +5,21 @@ within the common library.
 {{- define "common.classes.ingress" -}}
 {{- $ingressName := include "common.names.fullname" . -}}
 {{- $values := .Values.ingress -}}
+
 {{- if hasKey . "ObjectValues" -}}
   {{- with .ObjectValues.ingress -}}
     {{- $values = . -}}
   {{- end -}}
 {{ end -}}
+
 {{- if hasKey $values "nameSuffix" -}}
   {{- $ingressName = printf "%v-%v" $ingressName $values.nameSuffix -}}
 {{ end -}}
+
+{{- $svc := index $.Values.services (keys $.Values.services | first) -}}
 {{- $svcName := $values.serviceName | default (include "common.names.fullname" .) -}}
-{{- $svcPort := $values.servicePort | default $.Values.service.port.port -}}
+{{- $svcPort := $values.servicePort | default $svc.port.port -}}
+
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/charts/stable/common/templates/classes/_portal.tpl
+++ b/charts/stable/common/templates/classes/_portal.tpl
@@ -2,6 +2,7 @@
 
 {{- if .Values.portal }}
 {{- if .Values.portal.enabled }}
+{{- $svc := index .Values.services (keys .Values.services | first) -}}
 {{- $host := "$node_ip" }}
 {{- $port := 443 }}
 {{- $protocol := "https" }}
@@ -11,16 +12,16 @@
 {{- if hasKey .Values "ingress" }}
   {{- if .Values.ingress.enabled }}
     {{- range .Values.ingress.hosts }}
-    {{- if .hostTpl }}
-    {{ $host = ( tpl .hostTpl $ ) }}
-    {{- else if .host }}
-    {{ $host = .host }}
-    {{- else }}
-    {{ $host = "$node_ip" }}
-    {{- end }}
-    {{- if .paths }}
-    {{- $path = (first .paths).path  }}
-    {{- end }}
+      {{- if .hostTpl }}
+        {{ $host = ( tpl .hostTpl $ ) }}
+      {{- else if .host }}
+        {{ $host = .host }}
+      {{- else }}
+        {{ $host = "$node_ip" }}
+      {{- end }}
+      {{- if .paths }}
+        {{- $path = (first .paths).path  }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -28,10 +29,10 @@
 {{- if and ( .Values.portal.ingressPort ) ( ne $host "$node_ip" ) }}
   {{- $port = .Values.portal.ingressPort }}
 {{- else  if eq $host "$node_ip" }}
-  {{- if eq .Values.service.type "NodePort" }}
-    {{- $port = .Values.service.port.nodePort }}
-    {{- if or ( eq .Values.service.port.protocol "HTTP" ) ( eq .Values.service.port.protocol "HTTPS" ) }}
-      {{- $portProtocol = .Values.service.port.protocol }}
+  {{- if eq $svc.type "NodePort" }}
+    {{- $port = $svc.port.nodePort }}
+    {{- if or ( eq $svc.port.protocol "HTTP" ) ( eq $svc.port.protocol "HTTPS" ) }}
+      {{- $portProtocol = $svc.port.protocol }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -3,7 +3,7 @@ This template serves as a blueprint for all Service objects that are created
 within the common library.
 */}}
 {{- define "common.classes.service" -}}
-{{- $values := .Values.service -}}
+{{- $values := index .Values.services (keys .Values.services | first) -}}
 {{- if hasKey . "ObjectValues" -}}
   {{- with .ObjectValues.service -}}
     {{- $values = . -}}

--- a/charts/stable/common/templates/lib/controller/_ports.tpl
+++ b/charts/stable/common/templates/lib/controller/_ports.tpl
@@ -2,49 +2,41 @@
 Ports included by the controller.
 */}}
 {{- define "common.controller.ports" -}}
-  {{- $ports := list -}}
-  {{- with .Values.service -}}
-    {{- $serviceValues := deepCopy . -}}
-    {{/* append the ports for the main service */}}
-    {{- if .enabled -}}
-      {{- $_ := set .port "name" (default "http" .port.name) -}}
-      {{- $ports = mustAppend $ports .port -}}
-      {{- range $_ := .additionalPorts -}}
-        {{/* append the additonalPorts for the main service */}}
-        {{- $ports = mustAppend $ports . -}}
-      {{- end }}
-    {{- end }}
-    {{/* append the ports for each additional service */}}
-    {{- range $_ := .additionalServices }}
-      {{- if .enabled -}}
-        {{- $_ := set .port "name" (required "Missing port.name" .port.name) -}}
-        {{- $ports = mustAppend $ports .port -}}
-        {{- range $_ := .additionalPorts -}}
-          {{/* append the additonalPorts for each additional service */}}
-          {{- $ports = mustAppend $ports . -}}
+{{- $ports := list -}}
+    {{/* append the ports for each service */}}
+    {{- if $.Values.services -}}
+      {{- range $name, $_ := $.Values.services }}
+        {{- if .enabled -}}
+          {{- if kindIs "string" $name -}}
+            {{- $_ := set .port "name" (default .port.name | default $name) -}}
+            {{- else -}}
+            {{- $_ := set .port "name" (required "Missing port.name" .port.name) -}}
+          {{- end -}}
+          {{- $ports = mustAppend $ports .port -}}
+          {{- range $_ := .additionalPorts -}}
+            {{/* append the additonalPorts for each additional service */}}
+            {{- $ports = mustAppend $ports . -}}
+          {{- end }}
         {{- end }}
       {{- end }}
     {{- end }}
-  {{- end }}
 
 {{/* export/render the list of ports */}}
 {{- if $ports -}}
 ports:
 {{- range $_ := $ports }}
-- name: {{ .name }}
+{{- $protocol := "" -}}
+{{- if or ( eq .protocol "HTTP" ) ( eq .protocol "HTTPS" ) }}
+  {{- $protocol = "TCP" -}}
+{{- else }}
+  {{- $protocol = .protocol | default "TCP" -}}
+{{- end }}
+- name: {{ required "The port's 'name' is not defined" .name }}
   {{- if and .targetPort (kindIs "string" .targetPort) }}
   {{- fail (printf "Our charts do not support named ports for targetPort. (port name %s, targetPort %s)" .name .targetPort) }}
   {{- end }}
   containerPort: {{ .targetPort | default .port }}
-  {{- if .protocol }}
-  {{- if or ( eq .protocol "HTTP" ) ( eq .protocol "HTTPS" ) ( eq .protocol "TCP" ) }}
-  protocol: TCP
-  {{- else }}
-  protocol: {{ .protocol }}
-  {{- end }}
-  {{- else }}
-  protocol: TCP
-  {{- end }}
+  protocol: {{ $protocol | default "TCP" }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/lib/controller/_probes.tpl
+++ b/charts/stable/common/templates/lib/controller/_probes.tpl
@@ -2,7 +2,8 @@
 Probes selection logic.
 */}}
 {{- define "common.controller.probes" -}}
-{{- $svcPort := .Values.service.port.name -}}
+{{- $svc := index .Values.services (keys .Values.services | first) -}}
+{{- $svcPort := $svc.port.name -}}
 {{- range $probeName, $probe := .Values.probes }}
   {{- if $probe.enabled -}}
     {{- "" | nindent 0 }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -152,40 +152,38 @@ probes:
       periodSeconds: 5
       failureThreshold: 30
 
-service:
-  enabled: true
-  type: ClusterIP
-  ## Specify the default port information
-  ## It is adviced not to mix different port protocols on the same service
-  port:
+services:
+  main:
+    enabled: true
+    type: ClusterIP
+    ## Specify the default port information
+    ## It is adviced not to mix different port protocols on the same service
     port:
-    ## name defaults to http
-    name:
-    ## Accepts: HTTP, HTTPS, TCP and UDP
-    ## HTTPS and HTTPS spawn a TCP service and get used for internal URL and name generation
-    protocol: HTTP
-    ## Specify a service targetPort if you wish to differ the service port from the application port.
-    ## If targetPort is specified, this port number is used in the container definition instead of
-    ## service.port.port. Therefore named ports are not supported for this field.
-    targetPort:
-    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      port:
+      ## name defaults to http
+      name:
+      ## Accepts: HTTP, HTTPS, TCP and UDP
+      ## HTTPS and HTTPS spawn a TCP service and get used for internal URL and name generation
+      protocol: HTTP
+      ## Specify a service targetPort if you wish to differ the service port from the application port.
+      ## If targetPort is specified, this port number is used in the container definition instead of
+      ## service.port.port. Therefore named ports are not supported for this field.
+      targetPort:
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
+    additionalPorts: []
+
+    ## Provide any additional annotations which may be required. This can be used to
+    ## set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     ##
-    # nodePort:
-  additionalPorts: []
+    annotations: {}
+    labels: {}
 
-  ## Provide any additional annotations which may be required. This can be used to
-  ## set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  ##
-  annotations: {}
-  labels: {}
-
-  ## additionalServices can be created as either a dict or a list.
-  ## In case of a dict, please use the nameSuffix as dict name
-  additionalServices: []
-  # - enabled: false
-  #   nameSuffix: api
+  ## additionalServices can be created as either a dict.
+  # additionalService:
   #   type: ClusterIP
   #   # Specify the default port information
   #   port:

--- a/helper-charts/common-test/values.yaml
+++ b/helper-charts/common-test/values.yaml
@@ -3,9 +3,10 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
-service:
-  port:
-    port: 8080
+services:
+  main:
+    port:
+      port: 8080
 
 ingress:
   enabled: true

--- a/test/stable/common/configmap_spec.rb
+++ b/test/stable/common/configmap_spec.rb
@@ -145,12 +145,14 @@ class Test < ChartTest
           ingress: {
             enabled: false
           },
-          service: {
-            type: "NodePort",
-            port: {
-              nodePort: 666
-            }
-          }
+          services: {
+            main: {
+              type: "NodePort",
+              port: {
+                nodePort: 666,
+              },
+            },
+          },
         }
         chart.value values
         configmap = chart.resources(kind: "ConfigMap").first
@@ -165,12 +167,14 @@ class Test < ChartTest
           ingress: {
             enabled: false
           },
-          service: {
-            type: "NodePort",
-            port: {
-              nodePort: 666
-            }
-          }
+          services: {
+            main: {
+              type: "NodePort",
+              port: {
+                nodePort: 666,
+              },
+            },
+          },
         }
         chart.value values
         configmap = chart.resources(kind: "ConfigMap").first
@@ -185,17 +189,19 @@ class Test < ChartTest
           ingress: {
             enabled: false
           },
-          service: {
-            type: "NodePort",
-            port: {
-              nodePort: 666,
-              protocol: "HTTPS"
-            }
-          }
+          services: {
+            main: {
+              type: "NodePort",
+              port: {
+                nodePort: 666,
+                protocol: "HTTPS",
+              },
+            },
+          },
         }
         chart.value values
         configmap = chart.resources(kind: "ConfigMap").first
-        assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
+        assert_equal(values[:services][:main][:port][:protocol], configmap["data"]["protocol"])
       end
 
       it 'uses nodeport port protocol as protocol (HTTP)' do
@@ -206,17 +212,19 @@ class Test < ChartTest
           ingress: {
             enabled: false
           },
-          service: {
-            type: "NodePort",
-            port: {
-              nodePort: 666,
-              protocol: "HTTP"
-            }
-          }
+          services: {
+            main: {
+              type: "NodePort",
+              port: {
+                nodePort: 666,
+                protocol: "HTTP",
+              },
+            },
+          },
         }
         chart.value values
         configmap = chart.resources(kind: "ConfigMap").first
-        assert_equal(values[:service][:port][:protocol], configmap["data"]["protocol"])
+        assert_equal(values[:services][:main][:port][:protocol], configmap["data"]["protocol"])
       end
     end
 

--- a/test/stable/common/service_spec.rb
+++ b/test/stable/common/service_spec.rb
@@ -6,10 +6,10 @@ class Test < ChartTest
 
   describe @@chart.name do
     describe 'service::ports settings' do
-      default_name = 'http'
+      default_name = 'main'
       default_port = 8080
 
-      it 'defaults to name "http" on port 8080' do
+      it 'defaults to name "servicename" on port 8080' do
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(service)
         assert_equal(default_port, service["spec"]["ports"].first["port"])
@@ -25,61 +25,67 @@ class Test < ChartTest
 
       it 'port name can be overridden' do
         values = {
-          service: {
-            port: {
-              name: 'server'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                name: "server",
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(service)
         assert_equal(default_port, service["spec"]["ports"].first["port"])
-        assert_equal(values[:service][:port][:name], service["spec"]["ports"].first["targetPort"])
-        assert_equal(values[:service][:port][:name], service["spec"]["ports"].first["name"])
+        assert_equal(values[:services][:main][:port][:name], service["spec"]["ports"].first["targetPort"])
+        assert_equal(values[:services][:main][:port][:name], service["spec"]["ports"].first["name"])
 
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal(default_port, mainContainer["ports"].first["containerPort"])
-        assert_equal(values[:service][:port][:name], mainContainer["ports"].first["name"])
+        assert_equal(values[:services][:main][:port][:name], mainContainer["ports"].first["name"])
       end
 
       it 'targetPort can be overridden' do
         values = {
-          service: {
-            port: {
-              targetPort: 80
-            }
-          }
+          services: {
+            main: {
+              port: {
+                targetPort: 80,
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(service)
         assert_equal(default_port, service["spec"]["ports"].first["port"])
-        assert_equal(values[:service][:port][:targetPort], service["spec"]["ports"].first["targetPort"])
+        assert_equal(values[:services][:main][:port][:targetPort], service["spec"]["ports"].first["targetPort"])
         assert_equal(default_name, service["spec"]["ports"].first["name"])
 
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:service][:port][:targetPort], mainContainer["ports"].first["containerPort"])
+        assert_equal(values[:services][:main][:port][:targetPort], mainContainer["ports"].first["containerPort"])
         assert_equal(default_name, mainContainer["ports"].first["name"])
       end
 
       it 'targetPort cannot be a named port' do
         values = {
-          service: {
-            port: {
-              targetPort: 'test'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                targetPort: "test",
+              },
+            },
+          },
         }
         chart.value values
         exception = assert_raises HelmCompileError do
           chart.execute_helm_template!
         end
-        assert_match("Our charts do not support named ports for targetPort. (port name #{default_name}, targetPort #{values[:service][:port][:targetPort]})", exception.message)
+        assert_match("Our charts do not support named ports for targetPort. (port name #{default_name}, targetPort #{values[:services][:main][:port][:targetPort]})", exception.message)
       end
 
       it 'protocol defaults to TCP' do
@@ -95,11 +101,13 @@ class Test < ChartTest
 
       it 'protocol is TCP when set to TCP explicitly' do
         values = {
-          service: {
-            port: {
-              protocol: 'TCP'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                protocol: "TCP",
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
@@ -114,11 +122,13 @@ class Test < ChartTest
 
       it 'protocol is TCP when set to HTTP explicitly' do
         values = {
-          service: {
-            port: {
-              protocol: 'HTTP'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                protocol: "HTTP",
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
@@ -133,11 +143,13 @@ class Test < ChartTest
 
       it 'protocol is TCP when set to HTTPS explicitly' do
         values = {
-          service: {
-            port: {
-              protocol: 'HTTPS'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                protocol: "HTTPS",
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
@@ -152,11 +164,13 @@ class Test < ChartTest
 
       it 'protocol is UDP when set to UDP explicitly' do
         values = {
-          service: {
-            port: {
-              protocol: 'UDP'
-            }
-          }
+          services: {
+            main: {
+              port: {
+                protocol: "UDP",
+              },
+            },
+          },
         }
         chart.value values
         service = chart.resources(kind: "Service").find{ |s| s["metadata"]["name"] == "common-test" }
@@ -176,9 +190,11 @@ class Test < ChartTest
       end
       it 'TCP port protocol does not set annotations' do
         values = {
-          service: {
-            port: {
-              protocol: 'TCP'
+          services: {
+            main: {
+              port: {
+                protocol: 'TCP'
+              }
             }
           }
         }
@@ -189,9 +205,11 @@ class Test < ChartTest
       end
       it 'HTTPS port protocol sets traefik HTTPS annotation' do
         values = {
-          service: {
-            port: {
-              protocol: 'HTTPS'
+          services: {
+            main: {
+              port: {
+                protocol: 'HTTPS'
+              }
             }
           }
         }


### PR DESCRIPTION
**Description of the change**

This PR moves the primary service to a seperate dict called `main` under `service`.
While also moving the `additionalServices` down to their own named dicts under `service`

It's designed to be a minimal change, to prevent creating additional problems

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- More cleaner stucture for `Values.yaml`
- Less code (more efficient)
- Easy to expand in the future to add automatic paring of Ingresses and Services with the same name

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- Breaking change

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
