### PR TITLE
[common] Add support for SCALE GUI defined GPU's and .Values.resources unit-tests

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 2.5.0
+version: 2.6.0
 kubeVersion: ">=1.16.0-0"
 keywords:
 - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -242,6 +242,12 @@ All notable changes to this application Helm chart will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.6.0]
+
+#### Added
+
+- Added support for TrueNAS SCALE GUI configured GPU's
+
 ### [2.5.0]
 
 #### Added

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -69,8 +69,11 @@ The main container included in the controller.
     {{- . | nindent 2 }}
   {{- end }}
   {{- include "common.controller.probes" . | nindent 2 }}
-  {{- with .Values.resources }}
+
+  {{- $resources := dict "limits" ( .Values.scaleGPU | default dict ) }}
+  {{- $resources = merge $resources .Values.resources }}
   resources:
+  {{- with $resources }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -342,6 +342,9 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+## Used by TrueNAS SCALE to easily set add GPU's to Apps
+# scaleGPU: {}
+
 addons:
 
   # Enable running a VPN in the pod to route traffic through a VPN

--- a/test/stable/common/container_resources_spec.rb
+++ b/test/stable/common/container_resources_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require_relative '../../test_helper'
+
+class Test < ChartTest
+  @@chart = Chart.new('helper-charts/common-test')
+
+  describe @@chart.name do
+    describe 'container::resources' do
+      it 'no resources added by default' do
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal({"limits"=>{}}, mainContainer["resources"])
+      end
+      it 'resources can be added' do
+        values = {
+          resources: {
+            testresourcename: "testresourcevalue"
+          }
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal({"limits"=>{}, "testresourcename"=>"testresourcevalue"}, mainContainer["resources"])
+      end
+      it 'resources.limits can be added' do
+        values = {
+          resources: {
+            limits: {
+              testlimitkey: "testlimitvalue"
+            }
+          }
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal({"limits"=>{"testlimitkey"=>"testlimitvalue"}}, mainContainer["resources"])
+      end
+      it 'resources and resources.limits can both be added' do
+        values = {
+          resources: {
+            testresourcekey: "testresourcevalue",
+            limits: {
+              testlimitkey: "testlimitvalue"
+            }
+          }
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal({"limits"=>{"testlimitkey"=>"testlimitvalue"}, "testresourcekey"=>"testresourcevalue"}, mainContainer["resources"])
+      end
+    end
+    describe 'container::resources-scaleGPU' do
+      it 'scaleGPU can be set' do
+          values = {
+            scaleGPU: {
+              intelblabla: 1
+            }
+          }
+          chart.value values
+          deployment = chart.resources(kind: "Deployment").first
+          containers = deployment["spec"]["template"]["spec"]["containers"]
+          mainContainer = containers.find{ |c| c["name"] == "common-test" }
+          assert_equal({"limits"=>{"intelblabla"=>1}}, mainContainer["resources"])
+        end
+        it 'scaleGPU can be combined with resources and resource values' do
+          values = {
+            resources: {
+              testresourcekey: "testresourcevalue",
+              limits: {
+                testlimitkey: "testlimitvalue"
+              }
+            },
+            scaleGPU: {
+              intelblabla: 1
+            }
+          }
+          chart.value values
+          deployment = chart.resources(kind: "Deployment").first
+          containers = deployment["spec"]["template"]["spec"]["containers"]
+          mainContainer = containers.find{ |c| c["name"] == "common-test" }
+          assert_equal({"limits"=>{"intelblabla"=>1, "testlimitkey"=>"testlimitvalue"}, "testresourcekey"=>"testresourcevalue"}, mainContainer["resources"])
+        end
+      end
+  end
+end


### PR DESCRIPTION
**Description of the change**

This PR adds a simple way for TrueNAS SCALE to deploy GPU's as configured in the GUI.
It also adds unittests for setting resources and resources limits in Values.yaml

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

- More test coverage
- Compatibility with GPU's as configured in the TrueNAS SCALE GUI.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

- Slightly more complex codebase.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
