### PR TITLE
Additional cleanup/refactor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ ARG VARIANT="2"
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
 
 ARG HELM_VERSION="3.5.4"
+ARG CT_VERSION=3.3.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY Gemfile /tmp/Gemfile
@@ -16,6 +17,7 @@ RUN \
     libonig-dev \
     gnupg2 \
     python3-pip \
+    python3-setuptools \
   && \
   sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin \
   && \
@@ -23,7 +25,16 @@ RUN \
   && tar xvzf /tmp/helm.tar.gz -C /usr/local/bin --strip-components 1 "linux-$(dpkg --print-architecture)/helm" \
   && chmod +x /usr/local/bin/helm \
   && \
-  pip3 install pre-commit \
+  curl -o /tmp/ct.tar.gz -L "https://github.com/helm/chart-testing/releases/download/v${CT_VERSION}/chart-testing_${CT_VERSION}_linux_$(dpkg --print-architecture).tar.gz" \
+  && mkdir -p /etc/ct \
+  && tar xvzf /tmp/ct.tar.gz -C /usr/local/bin "ct" \
+  && tar xvzf /tmp/ct.tar.gz --strip-components=1 -C /etc/ct "etc/" \
+  && chmod +x /usr/local/bin/ct \
+  && \
+  pip3 install \
+    pre-commit \
+    yamale \
+    yamllint \
   && \
   bundle config set system 'true' \
   && bundle install --gemfile /tmp/Gemfile \
@@ -31,4 +42,5 @@ RUN \
   rm \
     /tmp/Gemfile \
     /tmp/Gemfile.lock \
-    /tmp/helm.tar.gz
+    /tmp/helm.tar.gz \
+    /tmp/ct.tar.gz

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/ruby
 {
-	"name": "Ruby",
-	"build": {
-		"context": "..",
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
-			"VARIANT": "2.7",
-		}
-	},
+    "name": "Ruby",
+    "build": {
+        "context": "..",
+        "dockerfile": "Dockerfile",
+        "args": {
+            // Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
+            "VARIANT": "2.7",
+        }
+    },
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-kubernetes-tools.vscode-kubernetes-tools",
-		"rebornix.Ruby"
-	],
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "rebornix.Ruby"
+    ],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "export RUBYJQ_USE_SYSTEM_LIBRARIES=1 && bundle install",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "export RUBYJQ_USE_SYSTEM_LIBRARIES=1 && bundle install",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }

--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
-        version: v3.4.0
+        version: v3.5.4
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
-        version: v3.4.0
+        version: v3.5.4
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v1
       with:
-        version: v3.4.0
+        version: v3.5.4
 
     - name: Run chart-releaser
       uses: helm/chart-releaser-action@v1.2.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
-	"recommendations": [
-		"ms-vscode-remote.remote-containers",
-		"rebornix.ruby"
-	]
+    "recommendations": [
+        "ms-vscode-remote.remote-containers",
+        "rebornix.ruby"
+    ]
 }

--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -3,7 +3,7 @@ name: common
 description: Function library for k8s-at-home charts
 type: library
 version: 3.0.0
-kubeVersion: ">=1.16"
+kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home
   - common

--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -3,15 +3,17 @@ name: common
 description: Function library for k8s-at-home charts
 type: library
 version: 3.0.0
-kubeVersion: ">=1.16.0-0"
+kubeVersion: ">=1.16"
 keywords:
 - k8s-at-home
 - common
 home: https://github.com/k8s-at-home/library-charts/tree/main/stable/common
 maintainers:
-- name: bjw-s
+  - name: bjw-s
   email: me@bjw-s.dev
 - name: onedr0p
   email: devin.kray@gmail.com
 - name: nicholaswilde
   email: ncwilde43@gmail.com
+  - name: dirtycajunrice
+    email: nick@cajun.pro

--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -5,15 +5,15 @@ type: library
 version: 3.0.0
 kubeVersion: ">=1.16"
 keywords:
-- k8s-at-home
-- common
+  - k8s-at-home
+  - common
 home: https://github.com/k8s-at-home/library-charts/tree/main/stable/common
 maintainers:
   - name: bjw-s
-  email: me@bjw-s.dev
-- name: onedr0p
-  email: devin.kray@gmail.com
-- name: nicholaswilde
-  email: ncwilde43@gmail.com
+    email: me@bjw-s.dev
+  - name: onedr0p
+    email: devin.kray@gmail.com
+  - name: nicholaswilde
+    email: ncwilde43@gmail.com
   - name: dirtycajunrice
     email: nick@cajun.pro

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -346,4 +346,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Open an [issue](https://github.com/k8s-at-home/charts/issues/new/choose)
 - Ask a [question](https://github.com/k8s-at-home/organization/discussions)
 - Join our [Discord](https://discord.gg/sTMX7Vh) community
-

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -8,7 +8,7 @@ Since a lot of the k8s-at-home charts follow a similar pattern, this library was
 
 ## Requirements
 
-Kubernetes: `>=1.16.0-0`
+Kubernetes: `>=1.16`
 
 ## Dependencies
 
@@ -80,7 +80,6 @@ N/A
 | addons.promtail.volumeMounts | list | `[]` | Specify a list of volumes that get mounted in the promtail container. At least 1 volumeMount is required! |
 | addons.vpn | object | See values.yaml | The common chart supports adding a VPN add-on. It can be configured under this key. For more info, check out [our docs](http://docs.k8s-at-home.com/our-helm-charts/common-library-add-ons/#wireguard-vpn) |
 | addons.vpn.configFile | string | `nil` | Provide a customized vpn configuration file to be used by the VPN. |
-| addons.vpn.configFileSecret | string | `nil` | Reference an existing secret that contains the VPN configuration file The chart expects it to be present under the `vpnConfigfile` key. |
 | addons.vpn.enabled | bool | `false` | Enable running a VPN in the pod to route traffic through a VPN |
 | addons.vpn.env | object | `{}` | All variables specified here will be added to the vpn sidecar container See the documentation of the VPN image for all config values |
 | addons.vpn.livenessProbe | object | `{}` | Optionally specify a livenessProbe, e.g. to check if the connection is still being protected by the VPN |
@@ -101,9 +100,15 @@ N/A
 | args | list | `[]` | Override the args for the default container |
 | autoscaling | object | <disabled> | Add a Horizontal Pod Autoscaler |
 | command | list | `[]` | Override the command(s) for the default container |
-| controllerAnnotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
-| controllerLabels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
-| controllerType | string | `"deployment"` | Set the controller type. Valid options are deployment, daemonset or statefulset |
+| controller.annotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
+| controller.labels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
+| controller.replicas | int | `1` | Number of desired pods |
+| controller.revisionHistoryLimit | int | `3` | ReplicaSet revision history limit |
+| controller.rollingUpdate.partition | string | `nil` | Set statefulset RollingUpdate partition |
+| controller.rollingUpdate.surge | string | `nil` | Set deployment RollingUpdate max surge |
+| controller.rollingUpdate.unavailable | string | `nil` | Set deployment RollingUpdate max unavailable |
+| controller.strategy | string | `nil` | Set the controller upgrade strategy For Deployments, valid values are Recreate (default) and RollingUpdate. For StatefulSets, valid values are OnDelete and RollingUpdate (default). DaemonSets ignore this. |
+| controller.type | string | `"deployment"` | Set the controller type. Valid options are deployment, daemonset or statefulset |
 | dnsConfig | object | `{}` | Optional DNS settings, configuring the ndots option may resolve nslookup issues on some Kubernetes setups. |
 | dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
 | enableServiceLinks | bool | `true` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
@@ -113,6 +118,8 @@ N/A
 | envTpl | object | `{}` | Environment variables with values set from Helm templates |
 | envValueFrom | object | `{}` | Variables with values from (for example) the Downward API [[ref]](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) |
 | fullnameOverride | string | `""` |  |
+| global.fullnameOverride | string | `nil` | Set the entire name definition |
+| global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
 | hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
 | hostPathMounts | list | `[]` | Mount a path on the host to the main container. |
@@ -165,7 +172,6 @@ N/A
 | probes.startup.custom | bool | `false` | Set this to `true` if you wish to specify your own startupProbe |
 | probes.startup.enabled | bool | `true` | Enable the startup probe |
 | probes.startup.spec | object | See below | The spec field contains the values for the default startupProbe. If you selected `custom: true`, this field holds the definition of the startupProbe. |
-| replicas | int | `1` | Number of desired pods |
 | resources | object | `{}` | Set the resource requests / limits for the main container. |
 | schedulerName | string | `nil` | Allows specifying a custom scheduler name |
 | secret | object | `{}` | Use this to populate a secret with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. |
@@ -187,9 +193,8 @@ N/A
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| strategy | object | RollingUpdate | Set the controller upgrade strategy For Deployments, valid values are Recreate and RollingUpdate. For StatefulSets, valid values are OnDelete and RollingUpdate. DaemonSets ignore this. |
 | tolerations | list | `[]` | Specify taint tolerations [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
-| volumeClaimTemplates | list | `[]` | Used in conjunction with `controllerType: statefulset` to create individual disks for each instance. |
+| volumeClaimTemplates | list | `[]` | Used in conjunction with `controller.type: statefulset` to create individual disks for each instance. |
 
 ## Changelog
 
@@ -345,5 +350,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ask a [question](https://github.com/k8s-at-home/organization/discussions)
 - Join our [Discord](https://discord.gg/sTMX7Vh) community
 
-----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -112,11 +112,7 @@ N/A
 | dnsConfig | object | `{}` | Optional DNS settings, configuring the ndots option may resolve nslookup issues on some Kubernetes setups. |
 | dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
 | enableServiceLinks | bool | `true` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
-| env | object | `{}` | Main environment variables. |
-| envFrom | list | `[]` | Environment variables that can be loaded from Secrets or ConfigMaps. [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables) |
-| envList | list | `[]` | Additional environment variables from a list. |
-| envTpl | object | `{}` | Environment variables with values set from Helm templates |
-| envValueFrom | object | `{}` | Variables with values from (for example) the Downward API [[ref]](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/) |
+| env | string | `nil` | Main environment variables. Template enabled. Syntax options: A) TZ: UTC B) PASSWD: '{{ .Release.Name }}' C) PASSWD:      envFrom:        ... D) - name: TZ      value: UTC E) - name: TZ      value: '{{ .Release.Name }}' |
 | fullnameOverride | string | `""` |  |
 | global.fullnameOverride | string | `nil` | Set the entire name definition |
 | global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
@@ -124,21 +120,22 @@ N/A
 | hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
 | hostPathMounts | list | `[]` | Mount a path on the host to the main container. |
 | hostname | string | `nil` | Allows specifying explicit hostname setting |
+| image.pullPolicy | string | `nil` |  |
+| image.repository | string | `nil` |  |
+| image.tag | string | `nil` |  |
 | ingress | object | See below | Configure the ingresses for the chart here. Additional ingresses can be added by adding a dictionary key similar to the 'main' ingress. |
 | ingress.main.annotations | object | `{}` | Provide additional annotations which may be required. |
 | ingress.main.enabled | bool | `false` | Enables or disables the ingress |
-| ingress.main.hosts[0].host | string | `"chart-example.local"` | Host address |
-| ingress.main.hosts[0].hostTpl | string | `nil` | A Helm template that is evaluated for the `host` field. |
-| ingress.main.hosts[0].paths[0].path | string | `"/"` | Path |
-| ingress.main.hosts[0].paths[0].pathTpl | string | `nil` | A Helm template that is evaluated for the `path` field. |
+| ingress.main.hosts[0].host | string | `"chart-example.local"` | Host address. Template enabled. |
+| ingress.main.hosts[0].paths[0].path | string | `"/"` | Path. Template enabled. |
 | ingress.main.hosts[0].paths[0].pathType | string | `"Prefix"` | Ignored if not kubeVersion >= 1.14-0 |
-| ingress.main.hosts[0].paths[0].serviceName | string | `nil` | Overrides the service name reference for this path |
-| ingress.main.hosts[0].paths[0].servicePort | string | `nil` | Overrides the service port reference for this path |
+| ingress.main.hosts[0].paths[0].service.name | string | `nil` | Overrides the service name reference for this path |
+| ingress.main.hosts[0].paths[0].service.port | string | `nil` | Overrides the service port reference for this path |
 | ingress.main.ingressClassName | string | `nil` | Set the ingressClass that is used for this ingress. Requires Kubernetes >=1.19 |
 | ingress.main.labels | object | `{}` | Provide additional labels which may be required. |
 | ingress.main.nameOverride | string | `nil` | Override the name suffix that is used for this ingress. |
 | ingress.main.primary | bool | `true` | Make this the primary ingress (used in probes, notes, etc...). If there is more than 1 ingress, make sure that only 1 ingress is marked as primary. |
-| ingress.main.tls | list | `[]` | Configure TLS for the ingress |
+| ingress.main.tls | list | `[]` | Configure TLS for the ingress. Both secretName and hosts are template enabled. |
 | initContainers | list | `[]` | Specify any initContainers here. Yaml will be passed in to the Pod as-is. |
 | lifecycle | object | `{}` | Configure the lifecycle for the main container |
 | nameOverride | string | `""` |  |

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -8,7 +8,7 @@ Since a lot of the k8s-at-home charts follow a similar pattern, this library was
 
 ## Requirements
 
-Kubernetes: `>=1.16`
+Kubernetes: `>=1.16.0-0`
 
 ## Dependencies
 
@@ -113,21 +113,20 @@ N/A
 | dnsPolicy | string | `nil` | Defaults to "ClusterFirst" if hostNetwork is false and "ClusterFirstWithHostNet" if hostNetwork is true. |
 | enableServiceLinks | bool | `true` | Enable/disable the generation of environment variables for services. [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service) |
 | env | string | `nil` | Main environment variables. Template enabled. Syntax options: A) TZ: UTC B) PASSWD: '{{ .Release.Name }}' C) PASSWD:      envFrom:        ... D) - name: TZ      value: UTC E) - name: TZ      value: '{{ .Release.Name }}' |
-| fullnameOverride | string | `""` |  |
 | global.fullnameOverride | string | `nil` | Set the entire name definition |
 | global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
 | hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
 | hostPathMounts | list | `[]` | Mount a path on the host to the main container. |
 | hostname | string | `nil` | Allows specifying explicit hostname setting |
-| image.pullPolicy | string | `nil` |  |
-| image.repository | string | `nil` |  |
-| image.tag | string | `nil` |  |
+| image.pullPolicy | string | `nil` | image pull policy |
+| image.repository | string | `nil` | image repository |
+| image.tag | string | `nil` | image tag |
 | ingress | object | See below | Configure the ingresses for the chart here. Additional ingresses can be added by adding a dictionary key similar to the 'main' ingress. |
 | ingress.main.annotations | object | `{}` | Provide additional annotations which may be required. |
 | ingress.main.enabled | bool | `false` | Enables or disables the ingress |
-| ingress.main.hosts[0].host | string | `"chart-example.local"` | Host address. Template enabled. |
-| ingress.main.hosts[0].paths[0].path | string | `"/"` | Path. Template enabled. |
+| ingress.main.hosts[0].host | string | `"chart-example.local"` | Host address. Helm template can be passed. |
+| ingress.main.hosts[0].paths[0].path | string | `"/"` | Path.  Helm template can be passed. |
 | ingress.main.hosts[0].paths[0].pathType | string | `"Prefix"` | Ignored if not kubeVersion >= 1.14-0 |
 | ingress.main.hosts[0].paths[0].service.name | string | `nil` | Overrides the service name reference for this path |
 | ingress.main.hosts[0].paths[0].service.port | string | `nil` | Overrides the service port reference for this path |
@@ -135,10 +134,9 @@ N/A
 | ingress.main.labels | object | `{}` | Provide additional labels which may be required. |
 | ingress.main.nameOverride | string | `nil` | Override the name suffix that is used for this ingress. |
 | ingress.main.primary | bool | `true` | Make this the primary ingress (used in probes, notes, etc...). If there is more than 1 ingress, make sure that only 1 ingress is marked as primary. |
-| ingress.main.tls | list | `[]` | Configure TLS for the ingress. Both secretName and hosts are template enabled. |
+| ingress.main.tls | list | `[]` | Configure TLS for the ingress. Both secretName and hosts can process a Helm template. |
 | initContainers | list | `[]` | Specify any initContainers here. Yaml will be passed in to the Pod as-is. |
 | lifecycle | object | `{}` | Configure the lifecycle for the main container |
-| nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node selection constraint [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
 | persistence | object | See below | Configure the persistent volumes for the chart here. Additional items can be added by adding a dictionary key similar to the 'config' key. |
 | persistence.config | object | See below | Default persistence for configuration files. |

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -27,14 +27,14 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{- include "common.serviceAccount" . }}
   {{- end -}}
 
-  {{- if eq .Values.controllerType "deployment" }}
+  {{- if eq .Values.controller.type "deployment" }}
     {{- include "common.deployment" . | nindent 0 }}
-  {{ else if eq .Values.controllerType "daemonset" }}
+  {{ else if eq .Values.controller.type "daemonset" }}
     {{- include "common.daemonset" . | nindent 0 }}
-  {{ else if eq .Values.controllerType "statefulset"  }}
+  {{ else if eq .Values.controller.type "statefulset"  }}
     {{- include "common.statefulset" . | nindent 0 }}
   {{ else }}
-    {{- fail (printf "Not a valid controllerType (%s)" .Values.controllerType) }}
+    {{- fail (printf "Not a valid controller.type (%s)" .Values.controller.type) }}
   {{- end -}}
 
   {{ include "common.classes.hpa" . | nindent 0 }}

--- a/charts/stable/common/templates/_daemonset.tpl
+++ b/charts/stable/common/templates/_daemonset.tpl
@@ -3,7 +3,7 @@ This template serves as the blueprint for the DaemonSet objects that are created
 within the common library.
 */}}
 {{- define "common.daemonset" -}}
-  {{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/stable/common/templates/_daemonset.tpl
+++ b/charts/stable/common/templates/_daemonset.tpl
@@ -3,32 +3,33 @@ This template serves as the blueprint for the DaemonSet objects that are created
 within the common library.
 */}}
 {{- define "common.daemonset" -}}
-{{- print ("---\n") | nindent 0 -}}
-apiVersion: {{ include "common.capabilities.daemonset.apiVersion" . }}
+  {{- print ("---\n") | nindent 0 -}}
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.controllerLabels }}
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.controller.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.controllerAnnotations }}
+  {{- with .Values.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   selector:
     matchLabels:
-    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "common.controller.pod" . | nindent 6 }}
 {{- end }}

--- a/charts/stable/common/templates/_daemonset.tpl
+++ b/charts/stable/common/templates/_daemonset.tpl
@@ -2,7 +2,7 @@
 This template serves as the blueprint for the DaemonSet objects that are created
 within the common library.
 */}}
-{{- define "common.daemonset" -}}
+{{- define "common.daemonset" }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/stable/common/templates/_deployment.tpl
+++ b/charts/stable/common/templates/_deployment.tpl
@@ -3,7 +3,7 @@ This template serves as the blueprint for the Deployment objects that are create
 within the common library.
 */}}
 {{- define "common.deployment" -}}
-  {{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/stable/common/templates/_deployment.tpl
+++ b/charts/stable/common/templates/_deployment.tpl
@@ -2,7 +2,7 @@
 This template serves as the blueprint for the Deployment objects that are created
 within the common library.
 */}}
-{{- define "common.deployment" -}}
+{{- define "common.deployment" }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/stable/common/templates/_deployment.tpl
+++ b/charts/stable/common/templates/_deployment.tpl
@@ -3,40 +3,51 @@ This template serves as the blueprint for the Deployment objects that are create
 within the common library.
 */}}
 {{- define "common.deployment" -}}
-{{- print ("---\n") | nindent 0 -}}
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+  {{- print ("---\n") | nindent 0 -}}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.controllerLabels }}
-    {{- toYaml . | nindent 4 }}
+    {{- with .Values.controller.labels }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.controllerAnnotations }}
+  {{- with .Values.controller.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicas }}
-  {{- with .Values.strategy }}
-  {{- if and (ne .type "Recreate") (ne .type "RollingUpdate") }}
-    {{- fail (printf "Not a valid strategy type for Deployment (%s)" .type) }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  replicas: {{ .Values.controller.replicas }}
+  {{- $strategy := default "Recreate" .Values.controller.strategy }}
+  {{- if and (ne $strategy "Recreate") (ne $strategy "RollingUpdate") }}
+    {{- fail (printf "Not a valid strategy type for Deployment (%s)" $strategy) }}
   {{- end }}
   strategy:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    type: {{ $strategy }}
+    {{- with .Values.controller.rollingUpdate }}
+      {{- if and (eq $strategy "RollingUpdate") (or .surge .unavailable) }}
+    rollingUpdate:
+        {{- with .unavailable }}
+      maxUnavailable: {{ . }}
+        {{- end }}
+        {{- with .surge }}
+      maxSurge: {{ . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   selector:
     matchLabels:
-    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "common.controller.pod" . | nindent 6 }}
 {{- end }}

--- a/charts/stable/common/templates/_ingress.tpl
+++ b/charts/stable/common/templates/_ingress.tpl
@@ -1,6 +1,4 @@
-{{/*
-Renders the Ingress objects required by the chart.
-*/}}
+{{/* Renders the Ingress objects required by the chart */}}
 {{- define "common.ingress" -}}
   {{- /* Generate named ingresses as required */ -}}
   {{- range $name, $ingress := .Values.ingress }}
@@ -10,7 +8,7 @@ Renders the Ingress objects required by the chart.
       {{/* set defaults */}}
       {{- if and (not $ingressValues.nameOverride) (ne $name (include "common.ingress.primary" $)) -}}
         {{- $_ := set $ingressValues "nameOverride" $name -}}
-      {{ end -}}
+      {{- end -}}
 
       {{- $_ := set $ "ObjectValues" (dict "ingress" $ingressValues) -}}
       {{- include "common.classes.ingress" $ }}
@@ -18,9 +16,7 @@ Renders the Ingress objects required by the chart.
   {{- end }}
 {{- end }}
 
-{{/*
-Return the name of the primary ingress object
-*/}}
+{{/* Return the name of the primary ingress object */}}
 {{- define "common.ingress.primary" -}}
   {{- $enabledIngresses := dict -}}
   {{- range $name, $ingress := .Values.ingress -}}

--- a/charts/stable/common/templates/_secret.tpl
+++ b/charts/stable/common/templates/_secret.tpl
@@ -1,7 +1,7 @@
 {{/*
 The Secret object to be created.
 */}}
-{{- define "common.secret" -}}
+{{- define "common.secret" }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/stable/common/templates/_secret.tpl
+++ b/charts/stable/common/templates/_secret.tpl
@@ -2,7 +2,7 @@
 The Secret object to be created.
 */}}
 {{- define "common.secret" -}}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/stable/common/templates/_serviceaccount.tpl
+++ b/charts/stable/common/templates/_serviceaccount.tpl
@@ -2,7 +2,7 @@
 The ServiceAccount object to be created.
 */}}
 {{- define "common.serviceAccount" -}}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/stable/common/templates/_serviceaccount.tpl
+++ b/charts/stable/common/templates/_serviceaccount.tpl
@@ -1,7 +1,7 @@
 {{/*
 The ServiceAccount object to be created.
 */}}
-{{- define "common.serviceAccount" -}}
+{{- define "common.serviceAccount" }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/stable/common/templates/_statefulset.tpl
+++ b/charts/stable/common/templates/_statefulset.tpl
@@ -3,7 +3,7 @@ This template serves as the blueprint for the StatefulSet objects that are creat
 within the common library.
 */}}
 {{- define "common.statefulset" -}}
-  {{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/stable/common/templates/_statefulset.tpl
+++ b/charts/stable/common/templates/_statefulset.tpl
@@ -3,55 +3,59 @@ This template serves as the blueprint for the StatefulSet objects that are creat
 within the common library.
 */}}
 {{- define "common.statefulset" -}}
-{{- print ("---\n") | nindent 0 -}}
-apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+  {{- print ("---\n") | nindent 0 -}}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
-  {{- include "common.labels" . | nindent 4 }}
-  {{- with .Values.controllerLabels }}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.controllerAnnotations }}
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.controller.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.controller.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  replicas: {{ .Values.replicas }}
-  {{- with .Values.strategy }}
-  {{- if and (ne .type "OnDelete") (ne .type "RollingUpdate") }}
-    {{- fail (printf "Not a valid strategy type for StatefulSet (%s)" .type) }}
-  {{- end }}
-  updateStrategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+spec:
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  replicas: {{ .Values.controller.replicas }}
+  {{- $strategy := default "RollingUpdate" .Values.controller.strategy }}
+  {{- if and (ne $strategy "OnDelete") (ne $strategy "RollingUpdate") }}
+    {{- fail (printf "Not a valid strategy type for StatefulSet (%s)" $strategy) }}
+  {{- end }}
+  updateStrategy:
+    type: {{ $strategy }}
+    {{- if and (eq $strategy "RollingUpdate") .Values.controller.rollingUpdate.partition }}
+    rollingUpdate:
+      partition: {{ .Values.controller.rollingUpdate.partition }}
+    {{- end }}
   selector:
     matchLabels:
-    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "common.names.fullname" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-      {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "common.labels.selectorLabels" . | nindent 8 }}
+        {{- include "common.labels.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "common.controller.pod" . | nindent 6 }}
   volumeClaimTemplates:
-  {{- range $index, $vct := .Values.volumeClaimTemplates }}
-  - metadata:
-      name: {{ $vct.name }}
-    spec:
-      accessModes:
-        - {{ required (printf "accessMode is required for vCT %v" $vct.name) $vct.accessMode  | quote }}
-      resources:
-        requests:
-          storage: {{ required (printf "size is required for PVC %v" $vct.name) $vct.size | quote }}
-      {{- if $vct.storageClass }}
-      storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-      {{- end }}
-{{- end }}
+    {{- range $index, $vct := .Values.volumeClaimTemplates }}
+    - metadata:
+        name: {{ $vct.name }}
+      spec:
+        accessModes:
+          - {{ required (printf "accessMode is required for vCT %v" $vct.name) $vct.accessMode  | quote }}
+        resources:
+          requests:
+            storage: {{ required (printf "size is required for PVC %v" $vct.name) $vct.size | quote }}
+        {{- if $vct.storageClass }}
+        storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else }}{{ $vct.storageClass | quote }}{{- end }}
+        {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/_statefulset.tpl
+++ b/charts/stable/common/templates/_statefulset.tpl
@@ -2,7 +2,7 @@
 This template serves as the blueprint for the StatefulSet objects that are created
 within the common library.
 */}}
-{{- define "common.statefulset" -}}
+{{- define "common.statefulset" }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/stable/common/templates/addons/code-server/_secret.tpl
+++ b/charts/stable/common/templates/addons/code-server/_secret.tpl
@@ -3,7 +3,7 @@ The OpenVPN credentials secrets to be included.
 */}}
 {{- define "common.addon.codeserver.deployKeySecret" -}}
 {{- if or .Values.addons.codeserver.git.deployKey .Values.addons.codeserver.git.deployKeyBase64 }}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/stable/common/templates/addons/promtail/_configmap.tpl
+++ b/charts/stable/common/templates/addons/promtail/_configmap.tpl
@@ -3,7 +3,7 @@ The promtail config to be included.
 */}}
 {{- define "common.addon.promtail.configmap" -}}
 {{- if .Values.addons.promtail.enabled }}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/stable/common/templates/addons/vpn/_configmap.tpl
+++ b/charts/stable/common/templates/addons/vpn/_configmap.tpl
@@ -3,7 +3,7 @@ The VPN config and scripts to be included.
 */}}
 {{- define "common.addon.vpn.configmap" -}}
 {{- if or .Values.addons.vpn.scripts.up .Values.addons.vpn.scripts.down }}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
+++ b/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
@@ -3,7 +3,7 @@ Blueprint for the NetworkPolicy object that can be included in the addon.
 */}}
 {{- define "common.addon.vpn.networkpolicy" -}}
 {{- if .Values.addons.vpn.networkPolicy.enabled -}}
-{{- print ("---\n") | nindent 0 -}}
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:

--- a/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
+++ b/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
@@ -2,7 +2,7 @@
 Blueprint for the NetworkPolicy object that can be included in the addon.
 */}}
 {{- define "common.addon.vpn.networkpolicy" -}}
-{{- if .Values.addons.vpn.networkPolicy.enabled -}}
+{{- if .Values.addons.vpn.networkPolicy.enabled }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1

--- a/charts/stable/common/templates/addons/vpn/_secret.tpl
+++ b/charts/stable/common/templates/addons/vpn/_secret.tpl
@@ -3,7 +3,7 @@ The OpenVPN config secret to be included.
 */}}
 {{- define "common.addon.vpn.secret" -}}
 {{- if and .Values.addons.vpn.configFile (not .Values.addons.vpn.configFileSecret) }}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
+++ b/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
@@ -3,7 +3,7 @@ The OpenVPN credentials secrets to be included.
 */}}
 {{- define "common.addon.openvpn.secret" -}}
 {{- with .Values.addons.vpn.openvpn.auth -}}
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
+++ b/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
@@ -2,7 +2,7 @@
 The OpenVPN credentials secrets to be included.
 */}}
 {{- define "common.addon.openvpn.secret" -}}
-{{- with .Values.addons.vpn.openvpn.auth -}}
+{{- with .Values.addons.vpn.openvpn.auth }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
+++ b/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
@@ -3,7 +3,7 @@ This template serves as a blueprint for horizontal pod autoscaler objects that a
 using the common library.
 */}}
 {{- define "common.classes.hpa" -}}
-  {{- if .Values.autoscaling.enabled }}
+  {{- if .Values.autoscaling.enabled -}}
     {{- print "---" | nindent 0 -}}
     {{- $hpaName := include "common.names.fullname" . -}}
     {{- $targetName := include "common.names.fullname" . -}}
@@ -33,5 +33,5 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-  {{- end }}
-{{- end 0}}
+  {{- end -}}
+{{- end -}}

--- a/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
+++ b/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
@@ -3,12 +3,10 @@ This template serves as a blueprint for horizontal pod autoscaler objects that a
 using the common library.
 */}}
 {{- define "common.classes.hpa" -}}
-{{- if .Values.autoscaling }}
-{{- if .Values.autoscaling.enabled }}
-{{- print "---" | nindent 0 -}}
-{{- $hpaName := include "common.names.fullname" . -}}
-{{- $targetName := include "common.names.fullname" . -}}
-
+  {{- if .Values.autoscaling.enabled }}
+    {{- print "---" | nindent 0 -}}
+    {{- $hpaName := include "common.names.fullname" . -}}
+    {{- $targetName := include "common.names.fullname" . -}}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -18,27 +16,22 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    {{- if eq .Values.controllerType "statefulset" }}
-    kind: StatefulSet
-    {{- else }}
-    kind: Deployment
-    {{- end }}
+    kind: {{ include "common.names.controllerType" . }}
     name: {{ .Values.autoscaling.target | default $targetName }}
   minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas | default 3 }}
   metrics:
-  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-  {{- end }}
-  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   {{- end }}
-{{- end }}
-{{- end }}
-{{- end -}}
+{{- end 0}}

--- a/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
+++ b/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
@@ -4,9 +4,9 @@ using the common library.
 */}}
 {{- define "common.classes.hpa" -}}
   {{- if .Values.autoscaling.enabled -}}
-    {{- print "---" | nindent 0 -}}
     {{- $hpaName := include "common.names.fullname" . -}}
-    {{- $targetName := include "common.names.fullname" . -}}
+    {{- $targetName := include "common.names.fullname" . }}
+---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -20,7 +20,7 @@ within the common library.
   {{- $primaryPort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
   {{- $name := include "common.names.name" . -}}
   {{- $isStable := include "common.capabilities.ingress.isStable" . -}}
-  {{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -19,7 +19,7 @@ within the common library.
   {{- $primaryService := get .Values.service (include "common.service.primary" .) }}
   {{- $primaryPort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
   {{- $name := include "common.names.name" . -}}
-  {{- $isStable := include "common.capabilities.ingress.isStable" . -}}
+  {{- $isStable := include "common.capabilities.ingress.isStable" . }}
 ---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -20,7 +20,7 @@ within the common library.
   {{- $name := $values.serviceName | default (include "common.names.fullname" .) -}}
   {{- $primaryPort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
   {{- $port := $values.servicePort | default $primaryPort.port -}}
-  {{- $isStable := include "common.capabilities.ingress.isStable" -}}
+  {{- $isStable := include "common.capabilities.ingress.isStable" . -}}
   {{- print ("---\n") | nindent 0 -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -5,9 +5,9 @@ before chart installation.
 {{- define "common.class.mountPermissions" -}}
   {{- if .Values.hostPathMounts -}}
     {{- $jobName := include "common.names.fullname" . -}}
-    {{- $user := dig "PUID" 568 .Values.env -}}
+    {{- $user := dig "PUID" 568 (default dict .Values.env) -}}
     {{- $user = dig "runAsUser" $user .Values.podSecurityContext -}}
-    {{- $group := dig "PGID" 568 .Values.env -}}
+    {{- $group := dig "PGID" 568 (default dict .Values.env) -}}
     {{- $user = dig "fsGroup" $user .Values.podSecurityContext -}}
     {{- $hostPathMounts := dict -}}
     {{- range $name, $mount := .Values.hostPathMounts -}}

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -5,10 +5,16 @@ before chart installation.
 {{- define "common.class.mountPermissions" -}}
   {{- if .Values.hostPathMounts -}}
     {{- $jobName := include "common.names.fullname" . -}}
-    {{- $user := dig "PUID" 568 (default dict .Values.env) -}}
+    {{- $user := 568 -}}
+    {{- if .Values.env -}}
+      {{- $user = dig "PUID" $user .Values.env -}}
+    {{- end -}}
     {{- $user = dig "runAsUser" $user .Values.podSecurityContext -}}
-    {{- $group := dig "PGID" 568 (default dict .Values.env) -}}
-    {{- $user = dig "fsGroup" $user .Values.podSecurityContext -}}
+    {{- $group := 568 -}}
+    {{- if and .Values.env -}}
+      {{- $group = dig "PGID" $group .Values.env -}}
+    {{- end -}}
+    {{- $group = dig "fsGroup" $group .Values.podSecurityContext -}}
     {{- $hostPathMounts := dict -}}
     {{- range $name, $mount := .Values.hostPathMounts -}}
       {{- if and $mount.enabled $mount.setPermissions -}}
@@ -40,7 +46,7 @@ spec:
             - -c
             - |
               {{- range $_, $hpm := $hostPathMounts }}
-              chown -R {{ printf "%s:%s %s" $user $group $hpm.mountPath }}
+              chown -R {{ printf "%d:%d %s" (int $user) (int $group) $hpm.mountPath }}
               {{- end }}
           volumeMounts:
             {{- range $name, $hpm := $hostPathMounts }}

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -3,40 +3,30 @@ This template serves as the blueprint for the mountPermissions job that is run
 before chart installation.
 */}}
 {{- define "common.class.mountPermissions" -}}
-{{- if .Values.hostPathMounts -}}
-
-{{- $jobName := include "common.names.fullname" . -}}
-{{- $values := .Values -}}
-{{- $user := 568 -}}
-{{- $group := 568 -}}
-{{- print "---" | nindent 0 -}}
-
-{{- if $values.podSecurityContext }}
-{{- if $values.podSecurityContext.runAsUser }}
-{{- $user = $values.podSecurityContext.runAsUser -}}
-{{- end -}}
-{{- if $values.podSecurityContext.fsGroup -}}
-{{- $group = $values.podSecurityContext.fsGroup -}}
-{{- end -}}
-{{- else if $values.env }}
-{{- if $values.env.PUID }}
-{{- $user = $values.env.PUID -}}
-{{- end -}}
-{{- if $values.env.PGID }}
-{{- $group = $values.env.PGID -}}
-{{- end -}}
-{{- end -}}
-
+  {{- if .Values.hostPathMounts -}}
+    {{- $jobName := include "common.names.fullname" . -}}
+    {{- $user := dig "PUID" 568 .Values.env -}}
+    {{- $user = dig "runAsUser" $user .Values.podSecurityContext -}}
+    {{- $group := dig "PGID" 568 .Values.env -}}
+    {{- $user = dig "fsGroup" $user .Values.podSecurityContext -}}
+    {{- $hostPathMounts := dict -}}
+    {{- range $name, $mount := .Values.hostPathMounts -}}
+      {{- if and $mount.enabled $mount.setPermissions -}}
+        {{- $name = default $name $mount.name -}}
+        {{- $_ := set $hostPathMounts $name $mount -}}
+      {{- end -}}
+    {{- end -}}
+    {{- print "---" | nindent 0 -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $jobName }}-autopermissions
+  name: {{ printf "%s-auto-permissions" $jobName }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
   annotations:
-   "helm.sh/hook": pre-install,pre-upgrade
-   "helm.sh/hook-weight": "-10"
-   "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed,before-hook-creation
 spec:
   template:
     metadata:
@@ -44,48 +34,31 @@ spec:
       restartPolicy: Never
       containers:
         - name: set-mount-permissions
-          image: "alpine:3.3"
+          image: alpine:3.3
           command:
-          - /bin/sh
-          - -c
-          - | {{ range $index, $hpm := .Values.hostPathMounts}}{{ if and $hpm.enabled $hpm.setPermissions}}
-            chown -R {{ print $user }}:{{ print $group }} {{ print $hpm.mountPath }}{{ end }}{{ end }}
-          #args:
-          #
-          #securityContext:
-          #
+            - /bin/sh
+            - -c
+            - |
+              {{- range $_, $hpm := $hostPathMounts }}
+              chown -R {{ printf "%s:%s %s" $user $group $hpm.mountPath }}
+              {{- end }}
           volumeMounts:
-          {{ range $name, $hpmm := .Values.hostPathMounts }}
-          {{- if $hpmm.enabled -}}
-          {{- if $hpmm.setPermissions -}}
-          {{ if $hpmm.name }}
-            {{ $name = $hpmm.name }}
-          {{ end }}
-          - name: hostpathmounts-{{ $name }}
-            mountPath: {{ $hpmm.mountPath }}
-            {{ if $hpmm.subPath }}
-            subPath: {{ $hpmm.subPath }}
-            {{ end }}
-          {{- end -}}
-          {{- end -}}
-          {{ end }}
+            {{- range $name, $hpm := $hostPathMounts }}
+            - name: {{ printf "hostpathmounts-%s" $name }}
+              mountPath: {{ $hpm.mountPath }}
+              {{- if $hpm.subPath }}
+              subPath: {{ $hpm.subPath }}
+              {{- end }}
+            {{- end }}
       volumes:
-      {{- range $name, $hpm := .Values.hostPathMounts -}}
-      {{ if $hpm.enabled }}
-      {{ if $hpm.setPermissions }}
-      {{ if $hpm.name }}
-      {{ $name = $hpm.name }}
-      {{ end }}
-      - name: hostpathmounts-{{ $name }}
-        {{ if $hpm.emptyDir }}
-        emptyDir: {}
-        {{- else -}}
-        hostPath:
-          path: {{ required "hostPath not set" $hpm.hostPath }}
-        {{ end }}
-      {{ end }}
-      {{ end }}
-      {{- end -}}
-
-{{- end }}
-{{- end }}
+        {{- range $name, $hpm := $hostPathMounts }}
+        - name: {{ printf "hostpathmounts-%s" $name }}
+          {{- if $hpm.emptyDir }}
+          emptyDir: {}
+          {{- else }}
+          hostPath:
+            path: {{ required "hostPath not set" $hpm.hostPath }}
+          {{- end }}
+        {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/charts/stable/common/templates/classes/_mountPermissions.tpl
+++ b/charts/stable/common/templates/classes/_mountPermissions.tpl
@@ -21,8 +21,8 @@ before chart installation.
         {{- $name = default $name $mount.name -}}
         {{- $_ := set $hostPathMounts $name $mount -}}
       {{- end -}}
-    {{- end -}}
-    {{- print "---" | nindent 0 -}}
+    {{- end }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/stable/common/templates/classes/_portal.tpl
+++ b/charts/stable/common/templates/classes/_portal.tpl
@@ -55,9 +55,7 @@
 {{- if and ( .Values.portal.path ) }}
   {{- $path = .Values.portal.path }}
 {{- end }}
-
-{{- print "---" | nindent 0 -}}
-
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -16,7 +16,7 @@ within the common library.
   {{ end -}}
 {{ end -}}
 
-{{- print ("---\n") | nindent 0 -}}
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -14,8 +14,7 @@ within the common library.
   {{- if not (eq $values.nameOverride "-") -}}
     {{- $pvcName = printf "%v-%v" $pvcName $values.nameOverride -}}
   {{ end -}}
-{{ end -}}
-
+{{ end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -17,7 +17,7 @@ within the common library.
 {{- $svcType := $values.type | default "" -}}
 {{- $primaryPort := get $values.ports (include "common.classes.service.ports.primary" (dict "values" $values)) -}}
 
-{{- print ("---\n") | nindent 0 -}}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -15,8 +15,7 @@ within the common library.
   {{- $serviceName = printf "%v-%v" $serviceName $values.nameOverride -}}
 {{ end -}}
 {{- $svcType := $values.type | default "" -}}
-{{- $primaryPort := get $values.ports (include "common.classes.service.ports.primary" (dict "values" $values)) -}}
-
+{{- $primaryPort := get $values.ports (include "common.classes.service.ports.primary" (dict "values" $values)) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/stable/common/templates/lib/chart/_capabilities.tpl
+++ b/charts/stable/common/templates/lib/chart/_capabilities.tpl
@@ -13,5 +13,7 @@
 
 {{/* Check Ingress stability */}}
 {{- define "common.capabilities.ingress.isStable" -}}
-  {{- eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+  {{- if eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+    {{- true -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/lib/chart/_capabilities.tpl
+++ b/charts/stable/common/templates/lib/chart/_capabilities.tpl
@@ -1,92 +1,17 @@
-{{/*
-Return the appropriate apiVersion for DaemonSet objects.
-*/}}
-{{- define "common.capabilities.daemonset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
+{{/* Allow KubeVersion to be overridden. */}}
+{{- define "common.capabilities.ingress.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
 {{- end -}}
 
-{{/*
-Waiting on https://github.com/helm/helm/pull/8608
-{{- define "common.capabilities.daemonset.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "apps/v1/DaemonSet" -}}
-{{- print "apps/v1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-*/}}
-
-{{/*
-Return the appropriate apiVersion for Deployment objects.
-*/}}
-{{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Waiting on https://github.com/helm/helm/pull/8608
-{{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
-{{- print "apps/v1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-*/}}
-
-{{/*
-Return the appropriate apiVersion for StatefulSet objects.
-*/}}
-{{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "apps/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Waiting on https://github.com/helm/helm/pull/8608
-{{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "apps/v1/StatefulSet" -}}
-{{- print "apps/v1" -}}
-{{- else -}}
-{{- print "apps/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-*/}}
-
-{{/*
-Return the appropriate apiVersion for Ingress objects.
-*/}}
-
+{{/* Return the appropriate apiVersion for Ingress objects */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end }}
+  {{- print "networking.k8s.io/v1" -}}
+  {{- if semverCompare "<1.19" (include "common.capabilities.ingress.kubeVersion" .) -}}
+    {{- print "beta1" -}}
+  {{- end -}}
 {{- end -}}
 
-{{/*
-Waiting on https://github.com/helm/helm/pull/8608
-{{- define "common.capabilities.ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end }}
+{{/* Check Ingress stability */}}
+{{- define "common.capabilities.ingress.isStable" -}}
+  {{- eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
 {{- end -}}
-*/}}

--- a/charts/stable/common/templates/lib/chart/_labels.tpl
+++ b/charts/stable/common/templates/lib/chart/_labels.tpl
@@ -1,19 +1,15 @@
-{{/*
-Common labels shared across objects.
-*/}}
+{{/* Common labels shared across objects */}}
 {{- define "common.labels" -}}
 helm.sh/chart: {{ include "common.names.chart" . }}
 {{ include "common.labels.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
+  {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+  {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
+{{- end -}}
 
-{{/*
-Selector labels shared across objects.
-*/}}
+{{/* Selector labels shared across objects */}}
 {{- define "common.labels.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "common.names.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}

--- a/charts/stable/common/templates/lib/chart/_names.tpl
+++ b/charts/stable/common/templates/lib/chart/_names.tpl
@@ -1,9 +1,7 @@
-{{/*
-Expand the name of the chart.
-*/}}
+{{/* Expand the name of the chart */}}
 {{- define "common.names.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
+  {{- default .Chart.Name (default .Values.nameOverride .Values.global.nameOverride) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
@@ -11,32 +9,42 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "common.names.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- $name := include "common.names.name" . -}}
+  {{- if or .Values.fullnameOverride .Values.global.fullnameOverride -}}
+    {{- $name = default .Values.fullnameOverride .Values.global.fullnameOverride -}}
+  {{- else -}}
+    {{- if contains $name .Release.Name -}}
+      {{- $name := .Release.Name -}}
+    {{- else -}}
+      {{- $name := printf "%s-%s" .Release.Name $name -}}
+    {{- end -}}
+  {{- end -}}
+  {{- trunc 63 $name | trimSuffix "-" -}}
+{{- end -}}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
+{{/* Create chart name and version as used by the chart label */}}
 {{- define "common.names.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
-{{/*
-Create the name of the ServiceAccount to use.
-*/}}
+{{/* Create the name of the ServiceAccount to use */}}
 {{- define "common.names.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-    {{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-    {{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+  {{- if .Values.serviceAccount.create -}}
+    {{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+  {{- else -}}
+    {{- default "default" .Values.serviceAccount.name -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Return the properly cased version of the controller type */}}
+{{- define "common.names.controllerType" -}}
+  {{- if eq .Values.controller.type "deployment" -}}
+    {{- print "Deployment" -}}
+  {{- else if eq .Values.controller.type "daemonset" -}}
+    {{- print "DaemonSet" -}}
+  {{- else if eq .Values.controller.type "statefulset"  -}}
+    {{- print "StatefulSet" -}}
+  {{ else }}
+    {{- fail (printf "Not a valid controller.type (%s)" .Values.controller.type) }}
+  {{- end -}}
+{{- end -}}

--- a/charts/stable/common/templates/lib/chart/_names.tpl
+++ b/charts/stable/common/templates/lib/chart/_names.tpl
@@ -44,7 +44,7 @@ If release name contains chart name it will be used as a full name.
     {{- print "DaemonSet" -}}
   {{- else if eq .Values.controller.type "statefulset"  -}}
     {{- print "StatefulSet" -}}
-  {{ else }}
-    {{- fail (printf "Not a valid controller.type (%s)" .Values.controller.type) }}
+  {{- else -}}
+    {{- fail (printf "Not a valid controller.type (%s)" .Values.controller.type) -}}
   {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/lib/chart/_values.tpl
+++ b/charts/stable/common/templates/lib/chart/_values.tpl
@@ -1,11 +1,9 @@
-{{/*
-Merge the local chart values and the common chart defaults.
-*/}}
+{{/* Merge the local chart values and the common chart defaults */}}
 {{- define "common.values.setup" -}}
   {{- if .Values.common -}}
     {{- $defaultValues := deepCopy .Values.common -}}
     {{- $userValues := deepCopy (omit .Values "common") -}}
     {{- $mergedValues := mustMergeOverwrite $defaultValues $userValues -}}
     {{- $_ := set . "Values" (deepCopy $mergedValues) -}}
-  {{- end }}
-{{- end }}
+  {{- end -}}
+{{- end -}}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -38,19 +38,17 @@
     - name: {{ quote $name }}
       {{- if kindIs "map" $value -}}
         {{- if hasKey $value "value" }}
-          {{- if or (kindIs "string" $value.value) (kindIs "float64" $value.value) (kindIs "int64" $value.value) }}
             {{- $value = $value.value -}}
-          {{- else }}
-            {{- $value = tpl $value.value $ | quote }}
-          {{- end }}
         {{- else if hasKey $value "valueFrom" }}
-      valueFrom:
-          {{- tpl $value.valueFrom $ | nindent 8 }}
+          {{- toYaml $value | nindent 6 }}
         {{- else }}
-          {{- fail "invalid env var format" }}
+          {{- dict "valueFrom" $value | toYaml | nindent 6 }}
         {{- end }}
       {{- end }}
       {{- if not (kindIs "map" $value) }}
+        {{- if kindIs "string" $value }}
+          {{- $value = tpl $value $ }}
+        {{- end }}
       value: {{ quote $value }}
       {{- end }}
     {{- end }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -2,66 +2,66 @@
 The pod definition included in the controller.
 */ -}}
 {{- define "common.controller.pod" -}}
-{{- with .Values.imagePullSecrets }}
+  {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-serviceAccountName: {{ include "common.names.serviceAccountName" . }}
-{{- with .Values.podSecurityContext }}
-securityContext:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.priorityClassName }}
-priorityClassName: {{ . }}
-{{- end }}
-{{- with .Values.schedulerName }}
-schedulerName: {{ . }}
-{{- end }}
-{{- with .Values.hostNetwork }}
-hostNetwork: {{ . }}
-{{- end }}
-{{- with .Values.hostname }}
-hostname: {{ . }}
-{{- end }}
-{{- if .Values.dnsPolicy }}
-dnsPolicy: {{ .Values.dnsPolicy }}
-{{- else if .Values.hostNetwork }}
-dnsPolicy: "ClusterFirstWithHostNet"
-{{- else }}
-dnsPolicy: ClusterFirst
-{{- end }}
-{{- with .Values.dnsConfig }}
-dnsConfig:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-enableServiceLinks: {{ .Values.enableServiceLinks }}
-{{- with .Values.initContainers }}
-initContainers:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-containers:
-  {{- include "common.controller.mainContainer" . | nindent 0 }}
-  {{- with .Values.additionalContainers }}
-    {{- tpl (toYaml .) $ | nindent 0 }}
+    {{- toYaml . | nindent 2 }}
   {{- end }}
-{{- with (include "common.controller.volumes" . | trim) }}
+serviceAccountName: {{ include "common.names.serviceAccountName" . }}
+  {{- with .Values.podSecurityContext }}
+securityContext:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.priorityClassName }}
+priorityClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.schedulerName }}
+schedulerName: {{ . }}
+  {{- end }}
+  {{- with .Values.hostNetwork }}
+hostNetwork: {{ . }}
+  {{- end }}
+  {{- with .Values.hostname }}
+hostname: {{ . }}
+  {{- end }}
+  {{- if .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy }}
+  {{- else if .Values.hostNetwork }}
+dnsPolicy: ClusterFirstWithHostNet
+  {{- else }}
+dnsPolicy: ClusterFirst
+  {{- end }}
+  {{- with .Values.dnsConfig }}
+dnsConfig:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+enableServiceLinks: {{ .Values.enableServiceLinks }}
+  {{- with .Values.initContainers }}
+initContainers:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+containers:
+  {{- include "common.controller.mainContainer" . | nindent 2 }}
+  {{- with .Values.additionalContainers }}
+    {{- tpl (toYaml .) $ | nindent 2 }}
+  {{- end }}
+  {{- with (include "common.controller.volumes" . | trim) }}
 volumes:
-  {{- . | nindent 0 }}
-{{- end }}
-{{- with .Values.hostAliases }}
+    {{- nindent 2 . }}
+  {{- end }}
+  {{- with .Values.hostAliases }}
 hostAliases:
-{{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.nodeSelector }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
 nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.affinity }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.affinity }}
 affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .Values.tolerations }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
 tolerations:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end -}}

--- a/charts/stable/common/templates/lib/controller/_volumemounts.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumemounts.tpl
@@ -1,49 +1,41 @@
-{{/*
-Volumes included by the controller.
-*/}}
+{{/* Volumes included by the controller */}}
 {{- define "common.controller.volumeMounts" -}}
-
-{{- range $index, $PVC := .Values.persistence }}
-{{- if $PVC.enabled }}
+  {{- range $index, $PVC := .Values.persistence }}
+    {{- if $PVC.enabled }}
 - mountPath: {{ $PVC.mountPath | default (printf "/%v" $index) }}
   name: {{ $index }}
-{{- if $PVC.subPath }}
+      {{- if $PVC.subPath }}
   subPath: {{ $PVC.subPath }}
-{{- end }}
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 
-{{- if .Values.additionalVolumeMounts }}
-{{- toYaml .Values.additionalVolumeMounts | nindent 0 }}
-{{- end }}
+  {{- if .Values.additionalVolumeMounts }}
+    {{- toYaml .Values.additionalVolumeMounts | nindent 0 }}
+  {{- end }}
 
-{{- if eq .Values.controllerType "statefulset"  }}
-{{- range $index, $vct := .Values.volumeClaimTemplates }}
+  {{- if eq .Values.controller.type "statefulset" }}
+    {{- range $index, $vct := .Values.volumeClaimTemplates }}
 - mountPath: {{ $vct.mountPath }}
   name: {{ $vct.name }}
-{{- if $vct.subPath }}
+      {{- if $vct.subPath }}
   subPath: {{ $vct.subPath }}
-{{- end }}
-{{- end }}
-{{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 
-{{/*
-Creates mountpoints to mount hostPaths directly to the container
-*/}}
-{{ range $name, $hpm := .Values.hostPathMounts }}
-{{- if $hpm.enabled -}}
-{{ if $hpm.name }}
-  {{ $name = $hpm.name }}
-{{ end }}
+  {{/* Creates mountpoints to mount hostPaths directly to the container */}}
+  {{- range $name, $hpm := .Values.hostPathMounts }}
+    {{- if $hpm.enabled }}
+      {{- $name = default $name $hpm.name }}
 - name: hostpathmounts-{{ $name }}
   mountPath: {{ $hpm.mountPath }}
-  {{ if $hpm.subPath }}
+      {{- if $hpm.subPath }}
   subPath: {{ $hpm.subPath }}
-  {{ end }}
-  {{ if $hpm.readOnly }}
+      {{- end }}
+      {{- if $hpm.readOnly }}
   readOnly: {{ $hpm.readOnly }}
+      {{- end }}
+    {{- end }}
   {{ end }}
-{{- end -}}
-{{ end }}
-
 {{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -30,17 +30,17 @@ controller:
   revisionHistoryLimit: 3
 
 image:
+  # -- image repository
   repository:
+  # -- image tag
   tag:
+  # -- image pull policy
   pullPolicy:
 
 # -- Override the command(s) for the default container
 command: []
 # -- Override the args for the default container
 args: []
-
-nameOverride: ""
-fullnameOverride: ""
 
 # -- Set annotations on the pod
 podAnnotations: {}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -264,7 +264,7 @@ ingress:
         host: chart-example.local
         ## Configure the paths for the host
         paths:
-          -  # -- Path. Template enabled.
+          -  # -- Path.  Helm template can be passed.
             path: /
             # -- Ignored if not kubeVersion >= 1.14-0
             pathType: Prefix

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -29,6 +29,11 @@ controller:
   # -- ReplicaSet revision history limit
   revisionHistoryLimit: 3
 
+image:
+  repository:
+  tag:
+  pullPolicy:
+
 # -- Override the command(s) for the default container
 command: []
 # -- Override the args for the default container
@@ -67,34 +72,18 @@ serviceAccount:
 secret: {}
   # PASSWORD: my-password
 
-# -- Main environment variables.
-env: {}
-  # TZ: UTC
-
-# -- Additional environment variables from a list.
-envList: []
-  # - name: TZ
-  #   value: UTC
-
-# -- Environment variables with values set from Helm templates
-## With a release name of: demo, the example env value will be: demo-admin
-envTpl: {}
-  # TEMPLATE_VALUE: "{{ .Release.Name }}-admin"
-
-# -- Variables with values from (for example) the Downward API
-# [[ref]](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/)
-envValueFrom: {}
-  # NODE_NAME:
-  #   fieldRef:
-  #     fieldPath: spec.nodeName
-
-# -- Environment variables that can be loaded from Secrets or ConfigMaps.
-# [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables)
-envFrom: []
-# - configMapRef:
-#     name: config-map-name
-# - secretRef:
-#     name: secret-name
+# -- Main environment variables. Template enabled.
+# Syntax options:
+# A) TZ: UTC
+# B) PASSWD: '{{ .Release.Name }}'
+# C) PASSWD:
+#      envFrom:
+#        ...
+# D) - name: TZ
+#      value: UTC
+# E) - name: TZ
+#      value: '{{ .Release.Name }}'
+env:
 
 # -- Custom priority class for different treatment by the scheduler
 priorityClassName:  # system-node-critical

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -274,7 +274,7 @@ ingress:
               # -- Overrides the service port reference for this path
               port:
 
-    # -- Configure TLS for the ingress. Both secretName and hosts are template enabled.
+    # -- Configure TLS for the ingress. Both secretName and hosts can process a Helm template.
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -260,7 +260,7 @@ ingress:
 
     ## Configure the hosts for the ingress
     hosts:
-      -  # -- Host address. Template enabled.
+      -  # -- Host address. Helm template can be passed.
         host: chart-example.local
         ## Configure the paths for the host
         paths:

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -9,9 +9,9 @@ controller:
   # Valid options are deployment, daemonset or statefulset
   type: deployment
   # -- Set annotations on the deployment/statefulset/daemonset
-  annotations: { }
+  annotations: {}
   # -- Set labels on the deployment/statefulset/daemonset
-  labels: { }
+  labels: {}
   # -- Number of desired pods
   replicas: 1
   # -- Set the controller upgrade strategy

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -1,21 +1,33 @@
-# -- Set the controller type.
-# Valid options are deployment, daemonset or statefulset
-controllerType: deployment
-# -- Set annotations on the deployment/statefulset/daemonset
-controllerAnnotations: {}
-# -- Set labels on the deployment/statefulset/daemonset
-controllerLabels: {}
+global:
+  # -- Set an override for the prefix of the fullname
+  nameOverride:
+  # -- Set the entire name definition
+  fullnameOverride:
 
-# -- Number of desired pods
-replicas: 1
-
-# -- Set the controller upgrade strategy
-# For Deployments, valid values are Recreate and RollingUpdate.
-# For StatefulSets, valid values are OnDelete and RollingUpdate.
-# DaemonSets ignore this.
-# @default -- RollingUpdate
-strategy:
-  type: RollingUpdate
+controller:
+  # -- Set the controller type.
+  # Valid options are deployment, daemonset or statefulset
+  type: deployment
+  # -- Set annotations on the deployment/statefulset/daemonset
+  annotations: { }
+  # -- Set labels on the deployment/statefulset/daemonset
+  labels: { }
+  # -- Number of desired pods
+  replicas: 1
+  # -- Set the controller upgrade strategy
+  # For Deployments, valid values are Recreate (default) and RollingUpdate.
+  # For StatefulSets, valid values are OnDelete and RollingUpdate (default).
+  # DaemonSets ignore this.
+  strategy:
+  rollingUpdate:
+    # -- Set deployment RollingUpdate max unavailable
+    unavailable:
+    # -- Set deployment RollingUpdate max surge
+    surge:
+    # -- Set statefulset RollingUpdate partition
+    partition:
+  # -- ReplicaSet revision history limit
+  revisionHistoryLimit: 3
 
 # -- Override the command(s) for the default container
 command: []
@@ -368,7 +380,7 @@ additionalVolumes: []
 # -- Specify any additional volume mounts for the main container here.
 additionalVolumeMounts: []
 
-# -- Used in conjunction with `controllerType: statefulset` to create individual disks for each instance.
+# -- Used in conjunction with `controller.type: statefulset` to create individual disks for each instance.
 volumeClaimTemplates: []
 # - name: data
 #   mountPath: /data

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -271,34 +271,25 @@ ingress:
 
     ## Configure the hosts for the ingress
     hosts:
-      -  # -- Host address
+      -  # -- Host address. Template enabled.
         host: chart-example.local
-        # -- A Helm template that is evaluated for the `host` field.
-        hostTpl:  # '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
-
-        ## Configure the hosts for the host
+        ## Configure the paths for the host
         paths:
-          -  # -- Path
+          -  # -- Path. Template enabled.
             path: /
-            # -- A Helm template that is evaluated for the `path` field.
-            pathTpl:  # '{{ include "common.names.fullname" . }}'
             # -- Ignored if not kubeVersion >= 1.14-0
             pathType: Prefix
-            # -- Overrides the service name reference for this path
-            serviceName:
-            # -- Overrides the service port reference for this path
-            servicePort:
+            service:
+              # -- Overrides the service name reference for this path
+              name:
+              # -- Overrides the service port reference for this path
+              port:
 
-    # -- Configure TLS for the ingress
+    # -- Configure TLS for the ingress. Both secretName and hosts are template enabled.
     tls: []
     #  - secretName: chart-example-tls
-    ## Or if you need a dynamic secretname
-    #  - secretNameTpl: '{{ include "common.names.fullname" . }}-ingress'
     #    hosts:
     #      - chart-example.local
-    ## Or a tpl that is evaluated
-    #    hostsTpl:
-    #      - '{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.{{ .Values.ingress.domainname }}'
 
 ## Adds a portal configmap for use with TrueNAS SCALE
 ## This should not be enabled on other systems than TrueNAS SCALE because it requires a seperate namespace for each chart.

--- a/test/stable/common/container_spec.rb
+++ b/test/stable/common/container_spec.rb
@@ -21,7 +21,7 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:command], mainContainer["command"])
+        assert_equal([values[:command]], mainContainer["command"])
       end
 
       it 'accepts a list of strings' do
@@ -55,7 +55,7 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:args], mainContainer["args"])
+        assert_equal([values[:args]], mainContainer["args"])
       end
 
       it 'accepts a list of strings' do

--- a/test/stable/common/container_spec.rb
+++ b/test/stable/common/container_spec.rb
@@ -83,11 +83,13 @@ class Test < ChartTest
         assert_nil(mainContainer["env"])
       end
 
-      it 'set "static" environment variables' do
+      it 'set static "k/v pair style" environment variables' do
         values = {
           env: {
-            STATIC_ENV: 'value_of_env',
-            TRUTHY_ENV: '0',
+            BOOL_ENV: false,
+            FLOAT_ENV: 4.2,
+            INT_ENV: 42,
+            STRING_ENV: 'value_of_env'
           }
         }
         chart.value values
@@ -98,52 +100,96 @@ class Test < ChartTest
         assert_equal(values[:env].values[0].to_s, mainContainer["env"][0]["value"])
         assert_equal(values[:env].keys[1].to_s, mainContainer["env"][1]["name"])
         assert_equal(values[:env].values[1].to_s, mainContainer["env"][1]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][2]["name"])
+        assert_equal(values[:env].values[2].to_s, mainContainer["env"][2]["value"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][3]["name"])
+        assert_equal(values[:env].values[3].to_s, mainContainer["env"][3]["value"])
       end
 
-      it 'set "list" of "static" environment variables' do
+      it 'set list of static "kubernetes style" environment variables' do
         values = {
-          envList: [
-          {
+          env: [
+            {
               name: 'STATIC_ENV_FROM_LIST',
               value: 'STATIC_ENV_VALUE_FROM_LIST'
-              }
-
+             }
           ]
         }
         chart.value values
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][0]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][0]["value"])
+        assert_equal(values[:env][0][:name].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env][0][:value].to_s, mainContainer["env"][0]["value"])
       end
 
-      it 'set both "list" AND "dict" of "static" environment variables' do
+      it 'set list of static "kubernetes valueFrom style" environment variables' do
+        values = {
+          env: [
+            {
+              name: 'STATIC_ENV_FROM_LIST',
+              valueFrom: {
+                 fieldRef: {
+                   fieldPath: "spec.nodeName"
+                 }
+              }
+            }
+          ]
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal(values[:env][0][:name].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env][0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][0]["valueFrom"]["fieldRef"]["fieldPath"])
+      end
+
+      it 'set both static "k/v pair style" and static "k/valueFrom style" environment variables' do
         values = {
           env: {
-            STATIC_ENV: 'value_of_env'
-          },
-          envList: [
-          {
-              name: 'STATIC_ENV_FROM_LIST',
-              value: 'STATIC_ENV_VALUE_FROM_LIST'
+            STATIC_ENV: 'value_of_env',
+            STATIC_ENV_FROM: {
+              valueFrom: {
+                 fieldRef: {
+                   fieldPath: "spec.nodeName"
+                 }
               }
-
-          ]
+            }
+          }
         }
         chart.value values
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][0]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][0]["value"])
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][1]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][1]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][0]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][1]["name"])
+        assert_equal(values[:env].values[1][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][1]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
-      it 'set "valueFrom" environment variables' do
+      it 'set static "k/explicitValueFrom pair style" environment variables' do
         values = {
-          envValueFrom: {
+          env: {
+            NODE_NAME: {
+              valueFrom: {
+                fieldRef: {
+                  fieldPath: "spec.nodeName"
+                }
+              }
+            }
+          }
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].values[0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][0]["valueFrom"]["fieldRef"]["fieldPath"])
+      end
+
+      it 'set static "k/implicitValueFrom pair style" environment variables' do
+        values = {
+          env: {
             NODE_NAME: {
               fieldRef: {
                 fieldPath: "spec.nodeName"
@@ -155,16 +201,30 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envValueFrom].keys[0].to_s, mainContainer["env"][0]["name"])
-        assert_equal(values[:envValueFrom].values[0][:fieldRef][:fieldPath], mainContainer["env"][0]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].values[0][:fieldRef][:fieldPath], mainContainer["env"][0]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
-      it 'set "static" and "Dynamic/Tpl" environment variables' do
+      it 'set both static "k/v pair style" and templated "k/v pair style" environment variables' do
         values = {
           env: {
+            DYN_ENV: "{{ .Release.Name }}-admin",
             STATIC_ENV: 'value_of_env'
-          },
-          envTpl: {
+          }
+        }
+        chart.value values
+        deployment = chart.resources(kind: "Deployment").first
+        containers = deployment["spec"]["template"]["spec"]["containers"]
+        mainContainer = containers.find{ |c| c["name"] == "common-test" }
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][0]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][1]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][1]["value"])
+      end
+
+      it 'set templated "k/v pair style" environment variables' do
+        values = {
+          env: {
             DYN_ENV: "{{ .Release.Name }}-admin"
           }
         }
@@ -173,23 +233,40 @@ class Test < ChartTest
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
         assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][0]["value"])
-        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][1]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][1]["value"])
+        assert_equal("common-test-admin", mainContainer["env"][0]["value"])
       end
 
-      it 'set "Dynamic/Tpl" environment variables' do
+      it 'set static "k/v pair style", templated "k/v pair style", static "k/explicitValueFrom pair style", and static "k/implicitValueFrom pair style" environment variables' do
         values = {
-          envTpl: {
-            DYN_ENV: "{{ .Release.Name }}-admin"
+          env: {
+            DYN_ENV: "{{ .Release.Name }}-admin",
+            STATIC_ENV: 'value_of_env',
+            STATIC_EXPLICIT_ENV_FROM: {
+              valueFrom: {
+                fieldRef: {
+                  fieldPath: "spec.nodeName"
+                }
+              }
+            },
+            STATIC_IMPLICIT_ENV_FROM: {
+              fieldRef: {
+                fieldPath: "spec.nodeName"
+              }
+            }
           }
         }
         chart.value values
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envTpl].keys[0].to_s, mainContainer["env"][0]["name"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][0]["name"])
         assert_equal("common-test-admin", mainContainer["env"][0]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][1]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][1]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][2]["name"])
+        assert_equal(values[:env].values[2][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][2]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][3]["name"])
+        assert_equal(values[:env].values[3][:fieldRef][:fieldPath], mainContainer["env"][3]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set "static" secret variables' do

--- a/test/stable/common/controller_spec.rb
+++ b/test/stable/common/controller_spec.rb
@@ -13,14 +13,14 @@ class Test < ChartTest
       end
 
       it 'accepts "statefulset"' do
-        chart.value controller.type: 'statefulset'
+        chart.value controller['type']: 'statefulset'
         assert_nil(resource('Deployment'))
         assert_nil(resource('DaemonSet'))
         refute_nil(resource('StatefulSet'))
       end
 
       it 'accepts "daemonset"' do
-        chart.value controller.type: 'daemonset'
+        chart.value controller['type']: 'daemonset'
         assert_nil(resource('Deployment'))
         assert_nil(resource('StatefulSet'))
         refute_nil(resource('DaemonSet'))
@@ -36,7 +36,7 @@ class Test < ChartTest
 
       it 'can set values for volumeClaimTemplates' do
         values = {
-          controller: {
+          controller = {
               type: 'statefulset',
           },
           volumeClaimTemplates: [

--- a/test/stable/common/controller_spec.rb
+++ b/test/stable/common/controller_spec.rb
@@ -13,14 +13,14 @@ class Test < ChartTest
       end
 
       it 'accepts "statefulset"' do
-        chart.value controllerType: 'statefulset'
+        chart.value controller.type: 'statefulset'
         assert_nil(resource('Deployment'))
         assert_nil(resource('DaemonSet'))
         refute_nil(resource('StatefulSet'))
       end
 
       it 'accepts "daemonset"' do
-        chart.value controllerType: 'daemonset'
+        chart.value controller.type: 'daemonset'
         assert_nil(resource('Deployment'))
         assert_nil(resource('StatefulSet'))
         refute_nil(resource('DaemonSet'))
@@ -29,14 +29,16 @@ class Test < ChartTest
 
     describe 'controller::statefulset::volumeClaimTemplates' do
       it 'volumeClaimTemplates should be empty by default' do
-        chart.value controllerType: 'statefulset'
+        chart.value controller.type: 'statefulset'
         statefulset = chart.resources(kind: "StatefulSet").first
         assert_nil(statefulset['spec']['volumeClaimTemplates'])
       end
 
       it 'can set values for volumeClaimTemplates' do
         values = {
-          controllerType: 'statefulset',
+          controller: {
+              type: 'statefulset',
+          },
           volumeClaimTemplates: [
             {
               name: 'storage',

--- a/test/stable/common/controller_spec.rb
+++ b/test/stable/common/controller_spec.rb
@@ -13,14 +13,14 @@ class Test < ChartTest
       end
 
       it 'accepts "statefulset"' do
-        chart.value controller['type']: 'statefulset'
+        chart.value controller: {type: 'statefulset'}
         assert_nil(resource('Deployment'))
         assert_nil(resource('DaemonSet'))
         refute_nil(resource('StatefulSet'))
       end
 
       it 'accepts "daemonset"' do
-        chart.value controller['type']: 'daemonset'
+        chart.value controller: {type: 'daemonset'}
         assert_nil(resource('Deployment'))
         assert_nil(resource('StatefulSet'))
         refute_nil(resource('DaemonSet'))
@@ -29,15 +29,15 @@ class Test < ChartTest
 
     describe 'controller::statefulset::volumeClaimTemplates' do
       it 'volumeClaimTemplates should be empty by default' do
-        chart.value controller.type: 'statefulset'
+        chart.value controller: {type: 'statefulset'}
         statefulset = chart.resources(kind: "StatefulSet").first
         assert_nil(statefulset['spec']['volumeClaimTemplates'])
       end
 
       it 'can set values for volumeClaimTemplates' do
         values = {
-          controller = {
-              type: 'statefulset',
+          controller: {
+            type: 'statefulset',
           },
           volumeClaimTemplates: [
             {

--- a/test/stable/common/ingress_spec.rb
+++ b/test/stable/common/ingress_spec.rb
@@ -94,7 +94,7 @@ class Test < ChartTest
             main: {
               tls: [
                 {
-                  secretNameTpl: '{{ .Release.Name }}-secret'
+                  secretName: '{{ .Release.Name }}-secret'
                 }
               ]
             }
@@ -114,9 +114,10 @@ class Test < ChartTest
             main: {
               hosts: [
                 {
+                  host: 'test.local',
                   paths: [
                     {
-                      pathTpl: '{{ .Release.Name }}.path'
+                      path: '{{ .Release.Name }}.path'
                     }
                   ]
                 }
@@ -162,7 +163,7 @@ class Test < ChartTest
             main: {
               hosts: [
                 {
-                  hostTpl: '{{ .Release.Name }}.hostname',
+                  host: '{{ .Release.Name }}.hostname',
                   paths: [
                     {
                       path: "/"
@@ -186,14 +187,17 @@ class Test < ChartTest
             main: {
               hosts: [
                 {
+                  host: 'test.local',
                   paths: [
                     {
                       path: '/'
                     },
                     {
                       path: '/second',
-                      serviceName: 'pathService',
-                      servicePort: 1234
+                      service: {
+                        name: 'pathService',
+                        port: 1234
+                      }
                     }
                   ]
                 }

--- a/test/stable/common/job_spec.rb
+++ b/test/stable/common/job_spec.rb
@@ -150,8 +150,8 @@ class Test < ChartTest
 
       it 'can process default (568:568) permissions for multiple volumes' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 568:568 /data
-chown -R 568:568 /config
+          command: ["/bin/sh", "-c", "chown -R 568:568 /config
+chown -R 568:568 /data
 "]
         }
         values = {
@@ -180,8 +180,8 @@ chown -R 568:568 /config
 
       it 'outputs default permissions with irrelevant podSecurityContext' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 568:568 /data
-chown -R 568:568 /config
+          command: ["/bin/sh", "-c", "chown -R 568:568 /config
+chown -R 568:568 /data
 "]
         }
         values = {
@@ -213,8 +213,8 @@ chown -R 568:568 /config
 
       it 'outputs fsgroup permissions for multiple volumes when set' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 568:666 /data
-chown -R 568:666 /config
+          command: ["/bin/sh", "-c", "chown -R 568:666 /config
+chown -R 568:666 /data
 "]
         }
         values = {
@@ -246,8 +246,8 @@ chown -R 568:666 /config
 
       it 'outputs runAsUser permissions for multiple volumes when set' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 999:568 /data
-chown -R 999:568 /config
+          command: ["/bin/sh", "-c", "chown -R 999:568 /config
+chown -R 999:568 /data
 "]
         }
         values = {
@@ -279,8 +279,8 @@ chown -R 999:568 /config
 
       it 'outputs fsGroup AND runAsUser permissions for multiple volumes when both are set' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 999:666 /data
-chown -R 999:666 /config
+          command: ["/bin/sh", "-c", "chown -R 999:666 /config
+chown -R 999:666 /data
 "]
         }
         values = {
@@ -312,8 +312,8 @@ chown -R 999:666 /config
       end
       it 'outputs PUID AND PGID permissions for multiple volumes when both are set' do
         results= {
-          command: ["/bin/sh", "-c", "chown -R 999:666 /data
-chown -R 999:666 /config
+          command: ["/bin/sh", "-c", "chown -R 999:666 /config
+chown -R 999:666 /data
 "]
         }
         values = {

--- a/test/stable/common/pod_spec.rb
+++ b/test/stable/common/pod_spec.rb
@@ -12,7 +12,12 @@ class Test < ChartTest
       end
 
       it 'accepts integer as value' do
-        chart.value replicas: 3
+        values = {
+          controller: {
+            replicas: 3
+          }
+        }
+        chart.value values
         deployment = chart.resources(kind: "Deployment").first
         assert_equal(3, deployment["spec"]["replicas"])
       end


### PR DESCRIPTION
**Description of the change**

more breakage!

**Benefits**

cleaner code, streamlined logic, consolidated variables, etc.

**Possible drawbacks**

its too late for that

**Major Changes**
* controller level values moved under the controller top level:
```yaml
controller:
  type: deployment
  annotations: { }
  labels: { }
  replicas: 1
  ```
  * strategy changed to string from list and default, if not defined, is decided based on type
  * rolling update strategy subconfiguration is now explicitly defined and only used in valid type
 
  ```yaml
controller:
  # -- Set the controller upgrade strategy
  # For Deployments, valid values are Recreate (default) and RollingUpdate.
  # For StatefulSets, valid values are OnDelete and RollingUpdate (default).
  # DaemonSets ignore this.
  strategy:
  rollingUpdate:
    # -- Set deployment RollingUpdate max unavailable
    unavailable:
    # -- Set deployment RollingUpdate max surge
    surge:
    # -- Set statefulset RollingUpdate partition
    partition:
  ```
  * revisionHistoryLimit is now configurable and defaulted to 3 from kube's 10 (yeesh was that verbose)
  ```yaml
controller:
  # -- ReplicaSet revision history limit
  revisionHistoryLimit: 3
  ```
* nameOverride and fullnameOverride are now defined via global but allow backwards compatibility with local references to allow sister charts to share the data
* compatibility checks for extensions/v1beta1 have been removed as they are long out of date
*  serviceName and portName in ingress have been moved to service.name and service.port to match service and new ingress struct
*  all env options outside of envFrom have been consolidated back to env:. All env outcomes are available from the original options.
```yaml
# -- Main environment variables. Template enabled.
# Syntax options:
# A) TZ: UTC
# B) PASSWD: '{{ .Release.Name }}'
# C) PASSWD:
#      envFrom:
#        ...
# D) - name: TZ
#      value: UTC
# E) - name: TZ
#      value: '{{ .Release.Name }}'
```