### PR TITLE
Enable setting of volume name on controller PVCs

### DIFF
--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -40,4 +40,7 @@ spec:
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else }}{{ $values.storageClass | quote }}{{- end }}
   {{- end }}
+  {{- if $values.volumeName }}
+  volumeName: {{ $values.volumeName | quote }}
+  {{- end }}
 {{- end -}}


### PR DESCRIPTION

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This change adds the `volumeName` field to the PVC class such that configured controller PVCs can indicate a specific `volumeName` when one exists to be bound.

**Benefits**

Allows the re-installation of application instances while retaining the same volume if it is accessible across multiple Kubernetes clusters.

**Possible drawbacks**

None that I can think of.

**Applicable issues**

None

**Additional information**

None

**Checklist**

- [x] `volumeName` field added to PVC class file.
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
