### PR TITLE
Correct service object root key in Changelog

### DIFF
--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -244,7 +244,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved the primary ingress from `ingress` to `ingress.main`.
 - Moved the primary service from `service` to `service.main`.
 - Multiple ingress objects can now be specified under the `ingress` key.
-- Multiple service objects can now be specified under the `ingress` key.
+- Multiple service objects can now be specified under the `service` key.
 - `nameSuffix` has been renamed to `nameOverride`.
 - `hostPathMounts` has been integrated with `persistence`.
 - `additionalVolumes` has been integrated with `persistence`.

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved the primary ingress from `ingress` to `ingress.main`.
 - Moved the primary service from `service` to `service.main`.
 - Multiple ingress objects can now be specified under the `ingress` key.
-- Multiple service objects can now be specified under the `ingress` key.
+- Multiple service objects can now be specified under the `service` key.
 - `nameSuffix` has been renamed to `nameOverride`.
 - `hostPathMounts` has been integrated with `persistence`.
 - `additionalVolumes` has been integrated with `persistence`.


### PR DESCRIPTION
**Description of the change**

Noticed a incorrect association in the change log where services were being mentioned as under ingress, I have corrected that.  

**Benefits**

Less confusion.

**Possible drawbacks**

More confusion.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
