### PR TITLE
[common] Add topologySpreadConstraints to Common Chart

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 3.1.1
+version: 3.1.2
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 3.1.2
+version: 3.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -216,6 +216,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.1.2]
+
+#### Added
+
+- Support for specifying [topologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) for a pod.
+
 ### [3.1.1]
 
 #### Fixed
@@ -382,6 +388,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
+[3.1.2]: #3.1.2
+[3.1.1]: #3.1.1
 [3.1.0]: #3.1.0
 [3.0.2]: #3.0.2
 [3.0.1]: #3.0.1

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -206,6 +206,7 @@ N/A
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Specify taint tolerations [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| topologySpreadConstraints | list | `[]` | Defines topologySpreadConstraint rules. [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
 | volumeClaimTemplates | list | `[]` | Used in conjunction with `controller.type: statefulset` to create individual disks for each instance. |
 
 ## Changelog

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -216,7 +216,7 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [3.1.2]
+### [3.2.0]
 
 #### Added
 
@@ -388,7 +388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
-[3.1.2]: #3.1.2
+[3.2.0]: #3.2.0
 [3.1.1]: #3.1.1
 [3.1.0]: #3.1.0
 [3.0.2]: #3.0.2

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,7 +10,7 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [3.1.2]
+### [3.2.0]
 
 #### Added
 
@@ -182,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
-[3.1.2]: #3.1.2
+[3.2.0]: #3.2.0
 [3.1.1]: #3.1.1
 [3.1.0]: #3.1.0
 [3.0.2]: #3.0.2

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [3.1.2]
+
+#### Added
+
+- Support for specifying [topologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) for a pod.
+
 ### [3.1.1]
 
 #### Fixed
@@ -176,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
+[3.1.2]: #3.1.2
+[3.1.1]: #3.1.1
 [3.1.0]: #3.1.0
 [3.0.2]: #3.0.2
 [3.0.1]: #3.0.1

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -60,6 +60,10 @@ nodeSelector:
 affinity:
     {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- with .Values.tolerations }}
 tolerations:
     {{- toYaml . | nindent 2 }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -403,6 +403,10 @@ nodeSelector: {}
 # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
 affinity: {}
 
+# -- Defines topologySpreadConstraint rules.
+# [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+topologySpreadConstraints: []
+
 # -- Specify taint tolerations
 # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 tolerations: []

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -406,6 +406,10 @@ affinity: {}
 # -- Defines topologySpreadConstraint rules.
 # [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 topologySpreadConstraints: []
+# - maxSkew: <integer>
+#   topologyKey: <string>
+#   whenUnsatisfiable: <string>
+#   labelSelector: <object>
 
 # -- Specify taint tolerations
 # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)


### PR DESCRIPTION
**Description of the change**

I am adding `topologySpreadConstraints` as an option for a pod in the common chart. This allows for ensuring a specific spread of pods across multiple availability zones (as defined by the user) and what to do in the case that the spread cannot be maintained. Related K8s documentation is [here](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).

**Benefits**

Greater flexibility for pod management in the inheriting charts.

**Possible drawbacks**

Unknown.

**Applicable issues**

N/A

**Additional information**

Please let me know if there are any questions or issues. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
