### PR TITLE
Use targetPort for probes if set

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 3.2.0
+version: 3.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/templates/lib/controller/_probes.tpl
+++ b/charts/stable/common/templates/lib/controller/_probes.tpl
@@ -17,7 +17,11 @@ Probes selection logic.
     {{- else }}
       {{- if and $primaryService $primaryPort -}}
         {{- "tcpSocket:" | nindent 2 }}
-          {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
+          {{- if $primaryPort.targetPort }}
+            {{- printf "port: %v" $primaryPort.targetPort | nindent 4 }}
+          {{- else}}
+            {{- printf "port: %v" $primaryPort.port | nindent 4 }}
+          {{- end }}
         {{- printf "initialDelaySeconds: %v" $probe.spec.initialDelaySeconds  | nindent 2 }}
         {{- printf "failureThreshold: %v" $probe.spec.failureThreshold  | nindent 2 }}
         {{- printf "timeoutSeconds: %v" $probe.spec.timeoutSeconds  | nindent 2 }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

If `targetPort` is set to a different port than the exposed service `port` the probes should check the container `targetPort` instead of the service port.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
