### PR TITLE
[common] Release common 4.0.0

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 3.3.0
+version: 4.0.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -207,6 +207,8 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
 ### [3.3.0]
 
 #### Added
@@ -399,6 +401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
+[4.0.0]: #400
 [3.3.0]: #330
 [3.2.0]: #320
 [3.1.1]: #311

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -49,7 +49,7 @@ N/A
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalContainers | list | `[]` | Specify any additional containers here. Yaml will be passed in to the Pod as-is. |
+| additionalContainers | object | `{}` | Specify any additional containers here as dictionary items. Each additional container should have its own key. Helm templates can be used. |
 | addons | object | See below | The common chart supports several add-ons. These can be configured under this key. |
 | addons.codeserver | object | See values.yaml | The common library supports adding a code-server add-on to access files. It can be configured under this key. For more info, check out [our docs](http://docs.k8s-at-home.com/our-helm-charts/common-library-add-ons/#code-server) |
 | addons.codeserver.args | list | `["--auth","none"]` | Set codeserver command line arguments. Consider setting --user-data-dir to a persistent location to preserve code-server setting changes |
@@ -140,7 +140,7 @@ N/A
 | ingress.main.nameOverride | string | `nil` | Override the name suffix that is used for this ingress. |
 | ingress.main.primary | bool | `true` | Make this the primary ingress (used in probes, notes, etc...). If there is more than 1 ingress, make sure that only 1 ingress is marked as primary. |
 | ingress.main.tls | list | `[]` | Configure TLS for the ingress. Both secretName and hosts can process a Helm template. |
-| initContainers | list | `[]` | Specify any initContainers here. Yaml will be passed in to the Pod as-is. |
+| initContainers | object | `{}` | Specify any initContainers here as dictionary items. Each initContainer should have its own key. The dictionary item key will determine the order. Helm templates can be used. |
 | lifecycle | object | `{}` | Configure the lifecycle for the main container |
 | nodeSelector | object | `{}` | Node selection constraint [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
 | persistence | object | See below | Configure persistence for the chart here. Additional items can be added by adding a dictionary key similar to the 'config' key. [[ref]](http://docs.k8s-at-home.com/our-helm-charts/common-library-storage) |
@@ -222,6 +222,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - **BREAKING**: Renamed the `skipuninstall` key to `retain` for `persistence` items.
+- **BREAKING**: `initContainers` now expects a dictionary instead of a list to make merging less error-prone. initContainers are ordered by their key.
+- **BREAKING**: `additionalContainers` now expects a dictionary instead of a list to make merging less error-prone.
 
 ### [3.3.0]
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -151,6 +151,7 @@ N/A
 | persistence.config.mountPath | string | `nil` | Where to mount the volume in the main container. Defaults to `/<name_of_the_volume>`, setting to '-' creates the volume but disables the volumeMount. |
 | persistence.config.nameOverride | string | `nil` | Override the name suffix that is used for this volume. |
 | persistence.config.readOnly | bool | `false` | Specify if the volume should be mounted read-only. |
+| persistence.config.retain | bool | `false` | Set to true to retain the PVC upon `helm uninstall` |
 | persistence.config.size | string | `"1Gi"` | The amount of storage that is requested for the persistent volume. |
 | persistence.config.storageClass | string | `nil` | Storage Class for the config volume. If set to `-`, dynamic provisioning is disabled. If set to something else, the given storageClass is used. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | persistence.config.subPath | string | `nil` | Used in conjunction with `existingClaim`. Specifies a sub-path inside the referenced volume instead of its root |
@@ -216,6 +217,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for specifying container termination message path and policy (#77).
 - Support for specifying Pod termination grace period.
+
+#### Changed
+
+- **BREAKING**: Renamed the `skipuninstall` key to `retain` for `persistence` items.
 
 ### [3.3.0]
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -217,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for specifying container termination message path and policy (#77).
 - Support for specifying Pod termination grace period.
+- Support for specifying PVC labels for `persistence` items.
 
 #### Changed
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -196,6 +196,9 @@ N/A
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| termination.gracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
+| termination.messagePath | string | `nil` | Configure the path at which the file to which the main container's termination message will be written. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
+| termination.messagePolicy | string | `nil` | Indicate how the main container's termination message should be populated. Valid options are `File` and `FallbackToLogsOnError`. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
 | tolerations | list | `[]` | Specify taint tolerations [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | topologySpreadConstraints | list | `[]` | Defines topologySpreadConstraint rules. [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
 | volumeClaimTemplates | list | `[]` | Used in conjunction with `controller.type: statefulset` to create individual disks for each instance. |
@@ -208,6 +211,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### [4.0.0]
+
+#### Added
+
+- Support for specifying container termination message path and policy (#77).
+- Support for specifying Pod termination grace period.
 
 ### [3.3.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,9 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.0.0]
+
+
 ### [3.3.0]
 
 #### Added
@@ -202,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `command` and `args` values now properly support both string and list values.
 
+[4.0.0]: #400
 [3.3.0]: #330
 [3.2.0]: #320
 [3.1.1]: #311

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for specifying container termination message path and policy (#77).
 - Support for specifying Pod termination grace period.
+- Support for specifying PVC labels for `persistence` items.
 
 #### Changed
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for specifying container termination message path and policy (#77).
 - Support for specifying Pod termination grace period.
 
+#### Changed
+
+- **BREAKING**: Renamed the `skipuninstall` key to `retain` for `persistence` items.
+
 ### [3.3.0]
 
 #### Added

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - **BREAKING**: Renamed the `skipuninstall` key to `retain` for `persistence` items.
+- **BREAKING**: `initContainers` now expects a dictionary instead of a list to make merging less error-prone. initContainers are ordered by their key.
+- **BREAKING**: `additionalContainers` now expects a dictionary instead of a list to make merging less error-prone.
 
 ### [3.3.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [4.0.0]
 
+#### Added
+
+- Support for specifying container termination message path and policy (#77).
+- Support for specifying Pod termination grace period.
 
 ### [3.3.0]
 

--- a/charts/stable/common/templates/addons/code-server/_codeserver.tpl
+++ b/charts/stable/common/templates/addons/code-server/_codeserver.tpl
@@ -7,8 +7,7 @@ It will include / inject the required templates based on the given values.
   {{/* Append the code-server container to the additionalContainers */}}
   {{- $container := include "common.addon.codeserver.container" . | fromYaml -}}
   {{- if $container -}}
-    {{- $additionalContainers := append .Values.additionalContainers $container -}}
-    {{- $_ := set .Values "additionalContainers" $additionalContainers -}}
+    {{- $_ := set .Values.additionalContainers "addon-codeserver" $container -}}
   {{- end -}}
 
   {{/* Include the deployKeySecret if not empty */}}

--- a/charts/stable/common/templates/addons/netshoot/_netshoot.tpl
+++ b/charts/stable/common/templates/addons/netshoot/_netshoot.tpl
@@ -7,8 +7,7 @@ It will include / inject the required templates based on the given values.
   {{/* Append the netshoot container to the additionalContainers */}}
   {{- $container := include "common.addon.netshoot.container" . | fromYaml -}}
   {{- if $container -}}
-    {{- $additionalContainers := append .Values.additionalContainers $container -}}
-    {{- $_ := set .Values "additionalContainers" $additionalContainers -}}
+    {{- $_ := set .Values.additionalContainers "addon-netshoot" $container -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/addons/promtail/_promtail.tpl
+++ b/charts/stable/common/templates/addons/promtail/_promtail.tpl
@@ -7,8 +7,7 @@ It will include / inject the required templates based on the given values.
   {{/* Append the promtail container to the additionalContainers */}}
   {{- $container := include "common.addon.promtail.container" . | fromYaml -}}
   {{- if $container -}}
-    {{- $additionalContainers := append .Values.additionalContainers $container -}}
-    {{- $_ := set .Values "additionalContainers" $additionalContainers -}}
+    {{- $_ := set .Values.additionalContainers "addon-promtail" $container -}}
   {{- end -}}
 
   {{/* Include the configmap if not empty */}}

--- a/charts/stable/common/templates/addons/vpn/openvpn/_addon.tpl
+++ b/charts/stable/common/templates/addons/vpn/openvpn/_addon.tpl
@@ -6,8 +6,7 @@ and add a credentials secret if speciffied.
   {{/* Append the openVPN container to the additionalContainers */}}
   {{- $container := include "common.addon.openvpn.container" . | fromYaml -}}
   {{- if $container -}}
-    {{- $additionalContainers := append .Values.additionalContainers $container -}}
-    {{- $_ := set .Values "additionalContainers" $additionalContainers -}}
+    {{- $_ := set .Values.additionalContainers "addon-openvpn" $container -}}
   {{- end -}}
 
   {{/* Include the secret if not empty */}}

--- a/charts/stable/common/templates/addons/vpn/wireguard/_addon.tpl
+++ b/charts/stable/common/templates/addons/vpn/wireguard/_addon.tpl
@@ -6,7 +6,6 @@ Template to render Wireguard addon. It will add the container to the list of add
   {{/* Append the Wireguard container to the additionalContainers */}}
   {{- $container := fromYaml (include "common.addon.wireguard.container" .) -}}
   {{- if $container -}}
-    {{- $additionalContainers := append .Values.additionalContainers $container -}}
-    {{- $_ := set .Values "additionalContainers" $additionalContainers -}}
+    {{- $_ := set .Values.additionalContainers "addon-wireguard" $container -}}
   {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -20,9 +20,9 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ $pvcName }}
-  {{- if or $values.skipuninstall $values.annotations }}
+  {{- if or $values.retain $values.annotations }}
   annotations:
-    {{- if $values.skipuninstall }}
+    {{- if $values.retain }}
     "helm.sh/resource-policy": keep
     {{- end }}
     {{- with $values.annotations }}

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -31,6 +31,9 @@ metadata:
   {{- end }}
   labels:
   {{- include "common.labels" . | nindent 4 }}
+  {{- with $values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ required (printf "accessMode is required for PVC %v" $pvcName) $values.accessMode | quote }}

--- a/charts/stable/common/templates/lib/controller/_container.tpl
+++ b/charts/stable/common/templates/lib/controller/_container.tpl
@@ -27,6 +27,13 @@
   lifecycle:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.termination.messagePath }}
+  terminationMessagePath: {{ . }}
+  {{- end }}
+  {{- with .Values.termination.messagePolicy }}
+  terminationMessagePolicy: {{ . }}
+  {{- end }}
+
   {{- with .Values.env }}
   env:
     {{- range $k, $v := . }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -35,6 +35,9 @@ dnsConfig:
     {{- toYaml . | nindent 2 }}
   {{- end }}
 enableServiceLinks: {{ .Values.enableServiceLinks }}
+  {{- with .Values.termination.gracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ . }}
+  {{- end }}
   {{- with .Values.initContainers }}
 initContainers:
     {{- toYaml . | nindent 2 }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -38,14 +38,29 @@ enableServiceLinks: {{ .Values.enableServiceLinks }}
   {{- with .Values.termination.gracePeriodSeconds }}
 terminationGracePeriodSeconds: {{ . }}
   {{- end }}
-  {{- with .Values.initContainers }}
+  {{- if .Values.initContainers }}
 initContainers:
-    {{- toYaml . | nindent 2 }}
+    {{- $initContainers := list }}
+    {{- range $index, $key := (keys .Values.initContainers | uniq | sortAlpha) }}
+      {{- $container := get $.Values.initContainers $key }}
+      {{- if not $container.name -}}
+        {{- $_ := set $container "name" $key }}
+      {{- end }}
+      {{- $initContainers = append $initContainers $container }}
+    {{- end }}
+    {{- tpl (toYaml $initContainers) $ | nindent 2 }}
   {{- end }}
 containers:
   {{- include "common.controller.mainContainer" . | nindent 2 }}
   {{- with .Values.additionalContainers }}
-    {{- tpl (toYaml .) $ | nindent 2 }}
+    {{- $additionalContainers := list }}
+    {{- range $name, $container := . }}
+      {{- if not $container.name -}}
+        {{- $_ := set $container "name" $name }}
+      {{- end }}
+      {{- $additionalContainers = append $additionalContainers $container }}
+    {{- end }}
+    {{- tpl (toYaml $additionalContainers) $ | nindent 2 }}
   {{- end }}
   {{- with (include "common.controller.volumes" . | trim) }}
 volumes:

--- a/charts/stable/common/tests/persistentvolumeclaim_test.go
+++ b/charts/stable/common/tests/persistentvolumeclaim_test.go
@@ -72,3 +72,95 @@ func (suite *PersistenceVolumeClaimTestSuite) TestStorageClass() {
         })
     }
 }
+
+func (suite *PersistenceVolumeClaimTestSuite) TestMetaData() {
+    defaultChartAnnotations := make(map[string]interface{})
+    defaultChartLabels := map[string]interface{}{
+        "app.kubernetes.io/instance":   "common-test",
+        "app.kubernetes.io/managed-by": "Helm",
+        "app.kubernetes.io/name":       "common-test",
+        "helm.sh/chart":                "common-test-0.1.0",
+    }
+
+    tests := map[string]struct {
+        values              []string
+        expectedAnnotations map[string]interface{}
+        expectedLabels      map[string]interface{}
+    }{
+        "Default": {
+            values: []string{
+                "persistence.config.enabled=true",
+            },
+            expectedAnnotations: nil,
+            expectedLabels:      nil,
+        },
+        "NoRetain": {
+            values: []string{
+                "persistence.config.enabled=true",
+                "persistence.config.labels.test_label=test",
+                "persistence.config.annotations.test_annotation=test",
+            },
+            expectedAnnotations: map[string]interface{}{
+                "test_annotation": "test",
+            },
+            expectedLabels: map[string]interface{}{
+                "test_label": "test",
+            },
+        },
+        "Retain": {
+            values: []string{
+                "persistence.config.enabled=true",
+                "persistence.config.retain=true",
+                "persistence.config.labels.test_label=test",
+                "persistence.config.annotations.test_annotation=test",
+            },
+            expectedAnnotations: map[string]interface{}{
+                "helm.sh/resource-policy": "keep",
+                "test_annotation":         "test",
+            },
+            expectedLabels: map[string]interface{}{
+                "test_label": "test",
+            },
+        },
+    }
+    for name, tc := range tests {
+        suite.Suite.Run(name, func() {
+            err := suite.Chart.Render(nil, tc.values, nil)
+            if err != nil {
+                suite.FailNow(err.Error())
+            }
+
+            pvcManifest := suite.Chart.Manifests.Get("PersistentVolumeClaim", "common-test-config")
+            suite.Assertions.NotEmpty(pvcManifest)
+
+            pvcAnnotations := pvcManifest.Path("metadata.annotations").Data()
+            testAnnotations := make(map[string]interface{})
+            for index, element := range defaultChartAnnotations {
+                testAnnotations[index] = element
+            }
+            for index, element := range tc.expectedAnnotations {
+                testAnnotations[index] = element
+            }
+
+            if len(testAnnotations) == 0 {
+                suite.Assertions.Equal(nil, pvcAnnotations)
+            } else {
+                suite.Assertions.EqualValues(testAnnotations, pvcAnnotations)
+            }
+
+            pvcLabels := pvcManifest.Path("metadata.labels").Data()
+            testLabels := make(map[string]interface{})
+            for index, element := range defaultChartLabels {
+                testLabels[index] = element
+            }
+            for index, element := range tc.expectedLabels {
+                testLabels[index] = element
+            }
+            if len(testLabels) == 0 {
+                suite.Assertions.Equal(nil, pvcLabels)
+            } else {
+                suite.Assertions.EqualValues(testLabels, pvcLabels)
+            }
+        })
+    }
+}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -343,8 +343,8 @@ persistence:
     # -- The amount of storage that is requested for the persistent volume.
     size: 1Gi
 
-    # - Set to true to retain the PVC upon `helm uninstall`
-    skipuninstall: false
+    # -- Set to true to retain the PVC upon `helm uninstall`
+    retain: false
 
   # -- Create an emptyDir volume to share between all containers
   # [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -124,11 +124,13 @@ securityContext: {}
 # -- Configure the lifecycle for the main container
 lifecycle: {}
 
-# -- Specify any initContainers here. Yaml will be passed in to the Pod as-is.
-initContainers: []
+# -- Specify any initContainers here as dictionary items. Each initContainer should have its own key.
+# The dictionary item key will determine the order. Helm templates can be used.
+initContainers: {}
 
-# -- Specify any additional containers here. Yaml will be passed in to the Pod as-is.
-additionalContainers: []
+# -- Specify any additional containers here as dictionary items. Each additional container should have its own key.
+# Helm templates can be used.
+additionalContainers: {}
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -183,6 +183,20 @@ probes:
       periodSeconds: 5
       failureThreshold: 30
 
+termination:
+  # -- Configure the path at which the file to which the main container's termination message will be written.
+  # -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)]
+  messagePath:
+
+  # -- Indicate how the main container's termination message should be populated.
+  # Valid options are `File` and `FallbackToLogsOnError`.
+  # -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)]
+  messagePolicy:
+
+  # -- Duration in seconds the pod needs to terminate gracefully
+  # -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)]
+  gracePeriodSeconds:
+
 # -- Configure the services for the chart here.
 # Additional services can be added by adding a dictionary key similar to the 'main' service.
 # @default -- See below


### PR DESCRIPTION
Signed-off-by: Bᴇʀɴᴅ Sᴄʜᴏʀɢᴇʀs <me@bjw-s.dev>

**Description of the change**

This updates our common library to version 4.0.0

**Benefits**

Several issues fixed, cleaned up code.

**Possible drawbacks**

Breaking changes are introduced:
- `skipuninstall` has been renamed to `retain` for dynamically created PVC's.
- `initContainers` and `additionalContainers` now both expect dicts instead of lists to make merging less error-prone

**Applicable issues**

- fixes #77
- fixes #79
- fixes #80 
- fixes #81
- fixes #82 

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
