### PR TITLE
[common] add optional configmaps as part of library-charts

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.0.1
+version: 4.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -103,8 +103,14 @@ N/A
 | addons.vpn.wireguard.image.tag | string | `"v1.0.20210424"` | Specify the WireGuard image tag |
 | affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | args | list | `[]` | Override the args for the default container |
+| automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | autoscaling | object | <disabled> | Add a Horizontal Pod Autoscaler |
 | command | list | `[]` | Override the command(s) for the default container |
+| configmap | object | See below | Configure configMaps for the chart here. Additional configMaps can be added by adding a dictionary key similar to the 'config' object. |
+| configmap.config.annotations | object | `{}` | Annotations to add to the configMap |
+| configmap.config.data | object | `{}` | configMap data content. Helm template enabled. |
+| configmap.config.enabled | bool | `false` | Enables or disables the configMap |
+| configmap.config.labels | object | `{}` | Labels to add to the configMap |
 | controller.annotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
 | controller.enabled | bool | `true` | enable the controller. |
 | controller.labels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
@@ -197,7 +203,6 @@ N/A
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | termination.gracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
 | termination.messagePath | string | `nil` | Configure the path at which the file to which the main container's termination message will be written. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
 | termination.messagePolicy | string | `nil` | Indicate how the main container's termination message should be populated. Valid options are `File` and `FallbackToLogsOnError`. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
@@ -217,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Support for specifying whether a pod should auto mount a service account token.
+- Support for specifying configMaps directly in values.yaml.
 
 ### [4.0.1]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,13 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.1.0]
+
+#### Added
+
+- Support for specifying whether a pod should auto mount a service account token.
+- Support for specifying configMaps directly in values.yaml.
+
 ### [4.0.1]
 
 #### Fixed

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -53,4 +53,8 @@ Main entrypoint for the common library chart. It will render all underlying temp
   {{- if .Values.secret -}}
     {{ include "common.secret" .  | nindent 0 }}
   {{- end -}}
+
+  {{- if .Values.configmap -}}
+    {{ include "common.configmap" . | nindent 0 }}
+  {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -25,6 +25,8 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{- include "common.addon.netshoot" . }}
   {{- end -}}
 
+  {{ include "common.configmap" . | nindent 0 }}
+
   {{- /* Build the templates */ -}}
   {{- include "common.pvc" . }}
 
@@ -52,9 +54,5 @@ Main entrypoint for the common library chart. It will render all underlying temp
 
   {{- if .Values.secret -}}
     {{ include "common.secret" .  | nindent 0 }}
-  {{- end -}}
-
-  {{- if .Values.configmap -}}
-    {{ include "common.configmap" . | nindent 0 }}
   {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/_configmap.tpl
+++ b/charts/stable/common/templates/_configmap.tpl
@@ -1,0 +1,17 @@
+{{/*
+The ConfigMap object to be created.
+*/}}
+{{- define "common.configmap" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+{{- with .Values.configmap.configData }}
+data:
+  {{ .configKey }}: |-
+  {{ .configValue | trim | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/stable/common/templates/_configmap.tpl
+++ b/charts/stable/common/templates/_configmap.tpl
@@ -1,17 +1,19 @@
 {{/*
-The ConfigMap object to be generated.
+Renders the configMap objects required by the chart.
 */}}
-{{- define "common.configmap" }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-{{- with .Values.configmap.configData }}
-data:
-  {{ .configKey }}: |-
-  {{ .configValue | trim | nindent 4 }}
-{{- end }}
+{{- define "common.configmap" -}}
+  {{- /* Generate named configMaps as required */ -}}
+  {{- range $name, $configmap := .Values.configmap }}
+    {{- if $configmap.enabled -}}
+      {{- $configmapValues := $configmap -}}
+
+      {{/* set the default nameOverride to the configMap name */}}
+      {{- if not $configmapValues.nameOverride -}}
+        {{- $_ := set $configmapValues "nameOverride" $name -}}
+      {{ end -}}
+
+      {{- $_ := set $ "ObjectValues" (dict "configmap" $configmapValues) -}}
+      {{- include "common.classes.configmap" $ }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/_configmap.tpl
+++ b/charts/stable/common/templates/_configmap.tpl
@@ -1,5 +1,5 @@
 {{/*
-The ConfigMap object to be created.
+The ConfigMap object to be generated.
 */}}
 {{- define "common.configmap" }}
 ---

--- a/charts/stable/common/templates/classes/_configmap.tpl
+++ b/charts/stable/common/templates/classes/_configmap.tpl
@@ -1,0 +1,37 @@
+{{/*
+This template serves as a blueprint for all configMap objects that are created
+within the common library.
+*/}}
+{{- define "common.classes.configmap" -}}
+  {{- $fullName := include "common.names.fullname" . -}}
+  {{- $configMapName := $fullName -}}
+  {{- $values := .Values.configmap -}}
+
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.configmap -}}
+      {{- $values = . -}}
+    {{- end -}}
+  {{ end -}}
+
+  {{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
+    {{- $configMapName = printf "%v-%v" $configMapName $values.nameOverride -}}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with $values.labels }}
+       {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+{{- with $values.data }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/stable/common/tests/configmap_test.go
+++ b/charts/stable/common/tests/configmap_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+    // "fmt"
+    "testing"
+
+    "github.com/k8s-at-home/library-charts/test/helmunit"
+    "github.com/stretchr/testify/suite"
+)
+
+type ConfigmapTestSuite struct {
+    suite.Suite
+    Chart helmunit.HelmChart
+}
+
+func (suite *ConfigmapTestSuite) SetupSuite() {
+    suite.Chart = helmunit.New("common-test", "../../../../helper-charts/common-test")
+    suite.Chart.UpdateDependencies()
+}
+
+// We need this function to kick off the test suite, otherwise
+// "go test" won't know about our tests
+func TestConfigmap(t *testing.T) {
+    suite.Run(t, new(ConfigmapTestSuite))
+}
+
+func (suite *ConfigmapTestSuite) TestValues() {
+    tests := map[string]struct {
+        values            []string
+        expectedConfigmap bool
+    }{
+        "Default": {
+            values:            nil,
+            expectedConfigmap: false,
+        },
+        "Disabled": {
+            values:            []string{"configmap.config.enabled=false"},
+            expectedConfigmap: false,
+        },
+        "Multiple": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+                "configmap.secondary.enabled=true",
+            },
+            expectedConfigmap: true,
+        },
+    }
+    for name, tc := range tests {
+        suite.Suite.Run(name, func() {
+            err := suite.Chart.Render(nil, tc.values, nil)
+            if err != nil {
+                suite.FailNow(err.Error())
+            }
+
+            configmapManifest := suite.Chart.Manifests.Get("ConfigMap", "common-test-config")
+            if tc.expectedConfigmap {
+                suite.Assertions.NotEmpty(configmapManifest)
+            } else {
+                suite.Assertions.Empty(configmapManifest)
+            }
+        })
+    }
+}
+
+func (suite *ConfigmapTestSuite) TestConfigmapName() {
+    tests := map[string]struct {
+        values       []string
+        expectedName string
+    }{
+        "Default": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+            },
+            expectedName: "common-test-config",
+        },
+        "CustomName": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+                "configmap.config.nameOverride=http",
+            },
+            expectedName: "common-test-http",
+        },
+    }
+    for name, tc := range tests {
+        suite.Suite.Run(name, func() {
+            err := suite.Chart.Render(nil, tc.values, nil)
+            if err != nil {
+                suite.FailNow(err.Error())
+            }
+
+            configmapManifest := suite.Chart.Manifests.Get("ConfigMap", tc.expectedName)
+            suite.Assertions.NotEmpty(configmapManifest)
+        })
+    }
+}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -77,6 +77,12 @@ serviceAccount:
 secret: {}
   # PASSWORD: my-password
 
+# -- Specifies whether a configmap should be created
+configmap:
+  # configData:
+    # configKey: "core.conf"
+    # configValue: ...
+
 # -- Main environment variables. Template enabled.
 # Syntax options:
 # A) TZ: UTC

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -80,11 +80,20 @@ automountServiceAccountToken: true
 secret: {}
   # PASSWORD: my-password
 
-# -- Specifies whether a configmap should be created
+# -- Configure configMaps for the chart here.
+# Additional configMaps can be added by adding a dictionary key similar to the 'config' object.
+# @default -- See below
 configmap:
-  # configData:
-    # configKey: "core.conf"
-    # configValue: ...
+  config:
+    # -- Enables or disables the configMap
+    enabled: false
+    # -- Labels to add to the configMap
+    labels: {}
+    # -- Annotations to add to the configMap
+    annotations: {}
+    # -- configMap data content. Helm template enabled.
+    data: {}
+      # foo: bar
 
 # -- Main environment variables. Template enabled.
 # Syntax options:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This PR allows for the creation of `ConfigMaps` as optional parameters in the values.yml file.
 
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Users will be able to create a `ConfigMap` for a project/chart, avoiding any manual steps to create one as described in an [example here](https://github.com/k8s-at-home/library-charts/pull/101#issuecomment-950162531).

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Currently this one provides a 1:1 mapping for a single `ConfigMap`.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related issue: https://github.com/k8s-at-home/library-charts/issues/67

**Additional information**

N/A

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
