### PR TITLE
[common] Version 4.1.0

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.0.1
+version: 4.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -166,7 +166,7 @@ N/A
 | persistence.config.size | string | `"1Gi"` | The amount of storage that is requested for the persistent volume. |
 | persistence.config.storageClass | string | `nil` | Storage Class for the config volume. If set to `-`, dynamic provisioning is disabled. If set to something else, the given storageClass is used. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 | persistence.config.subPath | string | `nil` | Used in conjunction with `existingClaim`. Specifies a sub-path inside the referenced volume instead of its root |
-| persistence.config.type | string | `"pvc"` | Sets the persistence type Valid options are pvc, emptyDir, hostPath or custom |
+| persistence.config.type | string | `"pvc"` | Sets the persistence type Valid options are pvc, emptyDir, hostPath, secret, configMap or custom |
 | persistence.shared | object | See below | Create an emptyDir volume to share between all containers [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) |
 | persistence.shared.medium | string | `nil` | Set the medium to "Memory" to mount a tmpfs (RAM-backed filesystem) instead of the storage medium that backs the node. |
 | persistence.shared.sizeLimit | string | `nil` | If the `SizeMemoryBackedVolumes` feature gate is enabled, you can specify a size for memory backed volumes. |
@@ -234,6 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for specifying configMaps directly in values.yaml.
 - Support for specifying annotations/labels on the VPN add-on `NetworkPolicy`.
 - Support for specifying custom podSelector labels on the VPN add-on `NetworkPolicy`.
+- Added `secret` and `configMap` as persistence types. [[ref]](http://docs.k8s-at-home.com/our-helm-charts/common-library-storage/).
 
 ### [4.0.1]
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -88,6 +88,11 @@ N/A
 | addons.vpn.enabled | bool | `false` | Enable running a VPN in the pod to route traffic through a VPN |
 | addons.vpn.env | object | `{}` | All variables specified here will be added to the vpn sidecar container See the documentation of the VPN image for all config values |
 | addons.vpn.livenessProbe | object | `{}` | Optionally specify a livenessProbe, e.g. to check if the connection is still being protected by the VPN |
+| addons.vpn.networkPolicy.annotations | object | `{}` | Provide additional annotations which may be required. |
+| addons.vpn.networkPolicy.egress | string | `nil` | The egress configuration for your network policy, All outbound traffic from the pod will be blocked unless specified here. [[ref]](https://kubernetes.io/docs/concepts/services-networking/network-policies/) [[recipes]](https://github.com/ahmetb/kubernetes-network-policy-recipes) |
+| addons.vpn.networkPolicy.enabled | bool | `false` | If set to true, will deploy a network policy that blocks all outbound traffic except traffic specified as allowed |
+| addons.vpn.networkPolicy.labels | object | `{}` | Provide additional labels which may be required. |
+| addons.vpn.networkPolicy.podSelectorLabels | object | `{}` | Provide additional podSelector labels which may be required. |
 | addons.vpn.openvpn | object | See below | OpenVPN specific configuration |
 | addons.vpn.openvpn.auth | string | `nil` | Credentials to connect to the VPN Service (used with -a) |
 | addons.vpn.openvpn.authSecret | string | `nil` | Optionally specify an existing secret that contains the credentials. Credentials should be stored under the `VPN_AUTH` key |
@@ -100,7 +105,7 @@ N/A
 | addons.vpn.wireguard | object | See below | WireGuard specific configuration |
 | addons.vpn.wireguard.image.pullPolicy | string | `"IfNotPresent"` | Specify the WireGuard image pull policy |
 | addons.vpn.wireguard.image.repository | string | `"ghcr.io/k8s-at-home/wireguard"` | Specify the WireGuard image |
-| addons.vpn.wireguard.image.tag | string | `"v1.0.20210424"` | Specify the WireGuard image tag |
+| addons.vpn.wireguard.image.tag | string | `"v1.0.20210914"` | Specify the WireGuard image tag |
 | affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | args | list | `[]` | Override the args for the default container |
 | automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
@@ -219,10 +224,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [4.1.0]
 
+#### Changed
+
+- Updated Wireguard add-on image tag to `v1.0.20210914`.
+
 #### Added
 
 - Support for specifying whether a pod should auto mount a service account token.
 - Support for specifying configMaps directly in values.yaml.
+- Support for specifying annotations/labels on the VPN add-on `NetworkPolicy`.
+- Support for specifying custom podSelector labels on the VPN add-on `NetworkPolicy`.
 
 ### [4.0.1]
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -197,6 +197,7 @@ N/A
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | termination.gracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
 | termination.messagePath | string | `nil` | Configure the path at which the file to which the main container's termination message will be written. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
 | termination.messagePolicy | string | `nil` | Indicate how the main container's termination message should be populated. Valid options are `File` and `FallbackToLogsOnError`. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
@@ -210,6 +211,12 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.1.0]
+
+#### Added
+
+- Support for specifying whether a pod should auto mount a service account token.
 
 ### [4.0.1]
 

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.0.1](https://img.shields.io/badge/Version-4.0.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -103,8 +103,14 @@ N/A
 | addons.vpn.wireguard.image.tag | string | `"v1.0.20210424"` | Specify the WireGuard image tag |
 | affinity | object | `{}` | Defines affinity constraint rules. [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | args | list | `[]` | Override the args for the default container |
+| automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | autoscaling | object | <disabled> | Add a Horizontal Pod Autoscaler |
 | command | list | `[]` | Override the command(s) for the default container |
+| configmap | object | See below | Configure configMaps for the chart here. Additional configMaps can be added by adding a dictionary key similar to the 'config' object. |
+| configmap.config.annotations | object | `{}` | Annotations to add to the configMap |
+| configmap.config.data | object | `{}` | configMap data content. Helm template enabled. |
+| configmap.config.enabled | bool | `false` | Enables or disables the configMap |
+| configmap.config.labels | object | `{}` | Labels to add to the configMap |
 | controller.annotations | object | `{}` | Set annotations on the deployment/statefulset/daemonset |
 | controller.enabled | bool | `true` | enable the controller. |
 | controller.labels | object | `{}` | Set labels on the deployment/statefulset/daemonset |
@@ -197,7 +203,6 @@ N/A
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| automountServiceAccountToken | bool | `true` | Specifies whether a service account token should be automatically mounted. |
 | termination.gracePeriodSeconds | string | `nil` | Duration in seconds the pod needs to terminate gracefully -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle)] |
 | termination.messagePath | string | `nil` | Configure the path at which the file to which the main container's termination message will be written. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
 | termination.messagePolicy | string | `nil` | Indicate how the main container's termination message should be populated. Valid options are `File` and `FallbackToLogsOnError`. -- [[ref](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle-1)] |
@@ -217,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Support for specifying whether a pod should auto mount a service account token.
+- Support for specifying configMaps directly in values.yaml.
 
 ### [4.0.1]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for specifying configMaps directly in values.yaml.
 - Support for specifying annotations/labels on the VPN add-on `NetworkPolicy`.
 - Support for specifying custom podSelector labels on the VPN add-on `NetworkPolicy`.
+- Added `secret` and `configMap` as persistence types. [[ref]](http://docs.k8s-at-home.com/our-helm-charts/common-library-storage/).
 
 ### [4.0.1]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -12,10 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [4.1.0]
 
+#### Changed
+
+- Updated Wireguard add-on image tag to `v1.0.20210914`.
+
 #### Added
 
 - Support for specifying whether a pod should auto mount a service account token.
 - Support for specifying configMaps directly in values.yaml.
+- Support for specifying annotations/labels on the VPN add-on `NetworkPolicy`.
+- Support for specifying custom podSelector labels on the VPN add-on `NetworkPolicy`.
 
 ### [4.0.1]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,13 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.1.0]
+
+#### Added
+
+- Support for specifying whether a pod should auto mount a service account token.
+- Support for specifying configMaps directly in values.yaml.
+
 ### [4.0.1]
 
 #### Fixed

--- a/charts/stable/common/templates/_all.tpl
+++ b/charts/stable/common/templates/_all.tpl
@@ -25,6 +25,8 @@ Main entrypoint for the common library chart. It will render all underlying temp
     {{- include "common.addon.netshoot" . }}
   {{- end -}}
 
+  {{ include "common.configmap" . | nindent 0 }}
+
   {{- /* Build the templates */ -}}
   {{- include "common.pvc" . }}
 

--- a/charts/stable/common/templates/_configmap.tpl
+++ b/charts/stable/common/templates/_configmap.tpl
@@ -1,0 +1,19 @@
+{{/*
+Renders the configMap objects required by the chart.
+*/}}
+{{- define "common.configmap" -}}
+  {{- /* Generate named configMaps as required */ -}}
+  {{- range $name, $configmap := .Values.configmap }}
+    {{- if $configmap.enabled -}}
+      {{- $configmapValues := $configmap -}}
+
+      {{/* set the default nameOverride to the configMap name */}}
+      {{- if not $configmapValues.nameOverride -}}
+        {{- $_ := set $configmapValues "nameOverride" $name -}}
+      {{ end -}}
+
+      {{- $_ := set $ "ObjectValues" (dict "configmap" $configmapValues) -}}
+      {{- include "common.classes.configmap" $ }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
+++ b/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
@@ -8,15 +8,26 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "common.names.fullname" . }}
+  labels:
+    {{- with .Values.addons.vpn.networkPolicy.labels }}
+       {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.addons.vpn.networkPolicy.annotations }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podSelector:
     matchLabels:
-    {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- include "common.labels.selectorLabels" . | nindent 6 }}
+      {{- with .Values.addons.vpn.networkPolicy.podSelectorLabels }}
+        {{ toYaml . | nindent 6 }}
+      {{- end }}
   policyTypes:
     - Egress
   egress:
-  {{- with .Values.addons.vpn.networkPolicy.egress }}
-    {{- . | toYaml | nindent 4 }}
-  {{- end -}}
+    {{- with .Values.addons.vpn.networkPolicy.egress }}
+      {{- . | toYaml | nindent 4 }}
+    {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_configmap.tpl
+++ b/charts/stable/common/templates/classes/_configmap.tpl
@@ -1,0 +1,37 @@
+{{/*
+This template serves as a blueprint for all configMap objects that are created
+within the common library.
+*/}}
+{{- define "common.classes.configmap" -}}
+  {{- $fullName := include "common.names.fullname" . -}}
+  {{- $configMapName := $fullName -}}
+  {{- $values := .Values.configmap -}}
+
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.configmap -}}
+      {{- $values = . -}}
+    {{- end -}}
+  {{ end -}}
+
+  {{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
+    {{- $configMapName = printf "%v-%v" $configMapName $values.nameOverride -}}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with $values.labels }}
+       {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+{{- with $values.data }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -7,6 +7,7 @@ imagePullSecrets:
     {{- toYaml . | nindent 2 }}
   {{- end }}
 serviceAccountName: {{ include "common.names.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
   {{- with .Values.podSecurityContext }}
 securityContext:
     {{- toYaml . | nindent 2 }}

--- a/charts/stable/common/templates/lib/controller/_volumes.tpl
+++ b/charts/stable/common/templates/lib/controller/_volumes.tpl
@@ -22,6 +22,23 @@ Volumes included by the controller.
     {{- end }}
   persistentVolumeClaim:
     claimName: {{ $pvcName }}
+  {{- else if or (eq $persistence.type "configMap") (eq $persistence.type "secret") }}
+    {{- $objectName := (required (printf "name not set for persistence item %s" $index) $persistence.name) }}
+    {{- $objectName = tpl $objectName $ }}
+    {{- if eq $persistence.type "configMap" }}
+  configMap:
+    name: {{ $objectName }}
+    {{- else }}
+  secret:
+    secretName: {{ $objectName }}
+    {{- end }}
+    {{- with $persistence.defaultMode }}
+    defaultMode: {{ . }}
+    {{- end }}
+    {{- with $persistence.items }}
+    items:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- else if eq $persistence.type "emptyDir" }}
     {{- $emptyDir := dict -}}
     {{- with $persistence.medium -}}

--- a/charts/stable/common/tests/configmap_test.go
+++ b/charts/stable/common/tests/configmap_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+    // "fmt"
+    "testing"
+
+    "github.com/k8s-at-home/library-charts/test/helmunit"
+    "github.com/stretchr/testify/suite"
+)
+
+type ConfigmapTestSuite struct {
+    suite.Suite
+    Chart helmunit.HelmChart
+}
+
+func (suite *ConfigmapTestSuite) SetupSuite() {
+    suite.Chart = helmunit.New("common-test", "../../../../helper-charts/common-test")
+    suite.Chart.UpdateDependencies()
+}
+
+// We need this function to kick off the test suite, otherwise
+// "go test" won't know about our tests
+func TestConfigmap(t *testing.T) {
+    suite.Run(t, new(ConfigmapTestSuite))
+}
+
+func (suite *ConfigmapTestSuite) TestValues() {
+    tests := map[string]struct {
+        values            []string
+        expectedConfigmap bool
+    }{
+        "Default": {
+            values:            nil,
+            expectedConfigmap: false,
+        },
+        "Disabled": {
+            values:            []string{"configmap.config.enabled=false"},
+            expectedConfigmap: false,
+        },
+        "Multiple": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+                "configmap.secondary.enabled=true",
+            },
+            expectedConfigmap: true,
+        },
+    }
+    for name, tc := range tests {
+        suite.Suite.Run(name, func() {
+            err := suite.Chart.Render(nil, tc.values, nil)
+            if err != nil {
+                suite.FailNow(err.Error())
+            }
+
+            configmapManifest := suite.Chart.Manifests.Get("ConfigMap", "common-test-config")
+            if tc.expectedConfigmap {
+                suite.Assertions.NotEmpty(configmapManifest)
+            } else {
+                suite.Assertions.Empty(configmapManifest)
+            }
+        })
+    }
+}
+
+func (suite *ConfigmapTestSuite) TestConfigmapName() {
+    tests := map[string]struct {
+        values       []string
+        expectedName string
+    }{
+        "Default": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+            },
+            expectedName: "common-test-config",
+        },
+        "CustomName": {
+            values: []string{
+                "configmap.config.enabled=true",
+                "configmap.config.data.foo=bar",
+                "configmap.config.nameOverride=http",
+            },
+            expectedName: "common-test-http",
+        },
+    }
+    for name, tc := range tests {
+        suite.Suite.Run(name, func() {
+            err := suite.Chart.Render(nil, tc.values, nil)
+            if err != nil {
+                suite.FailNow(err.Error())
+            }
+
+            configmapManifest := suite.Chart.Manifests.Get("ConfigMap", tc.expectedName)
+            suite.Assertions.NotEmpty(configmapManifest)
+        })
+    }
+}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -71,6 +71,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Specifies whether a service account token should be automatically mounted.
+automountServiceAccountToken: true
+
 # -- Use this to populate a secret with the values you specify.
 # Be aware that these values are not encrypted by default, and could therefore visible
 # to anybody with access to the values.yaml file.

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -474,7 +474,7 @@ addons:
         # -- Specify the WireGuard image
         repository: ghcr.io/k8s-at-home/wireguard
         # -- Specify the WireGuard image tag
-        tag: v1.0.20210424
+        tag: v1.0.20210914
         # -- Specify the WireGuard image pull policy
         pullPolicy: IfNotPresent
 
@@ -526,16 +526,24 @@ addons:
       # periodSeconds: 60
       # failureThreshold: 1
 
-    # If set to true, will deploy a network policy that blocks all outbound
-    # traffic except traffic specified as allowed
     networkPolicy:
+      # -- If set to true, will deploy a network policy that blocks all outbound
+      # traffic except traffic specified as allowed
       enabled: false
 
-      # The egress configuration for your network policy, All outbound traffic
-      # From the pod will be blocked unless specified here. Your cluster must
-      # have a CNI that supports network policies (Canal, Calico, etc...)
-      # https://kubernetes.io/docs/concepts/services-networking/network-policies/
-      # https://github.com/ahmetb/kubernetes-network-policy-recipes
+      # -- Provide additional annotations which may be required.
+      annotations: {}
+
+      # -- Provide additional labels which may be required.
+      labels: {}
+
+      # -- Provide additional podSelector labels which may be required.
+      podSelectorLabels: {}
+
+      # -- The egress configuration for your network policy, All outbound traffic
+      # from the pod will be blocked unless specified here.
+      # [[ref]](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+      # [[recipes]](https://github.com/ahmetb/kubernetes-network-policy-recipes)
       egress:
         # - to:
         #   - ipBlock:

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -80,6 +80,21 @@ automountServiceAccountToken: true
 secret: {}
   # PASSWORD: my-password
 
+# -- Configure configMaps for the chart here.
+# Additional configMaps can be added by adding a dictionary key similar to the 'config' object.
+# @default -- See below
+configmap:
+  config:
+    # -- Enables or disables the configMap
+    enabled: false
+    # -- Labels to add to the configMap
+    labels: {}
+    # -- Annotations to add to the configMap
+    annotations: {}
+    # -- configMap data content. Helm template enabled.
+    data: {}
+      # foo: bar
+
 # -- Main environment variables. Template enabled.
 # Syntax options:
 # A) TZ: UTC

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -331,7 +331,7 @@ persistence:
     enabled: false
 
     # -- Sets the persistence type
-    # Valid options are pvc, emptyDir, hostPath or custom
+    # Valid options are pvc, emptyDir, hostPath, secret, configMap or custom
     type: pvc
 
     # -- Where to mount the volume in the main container.


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

#### Changed

- Updated Wireguard add-on image tag to `v1.0.20210914`.

#### Added

- Support for specifying whether a pod should auto mount a service account token.
- Support for specifying configMaps directly in values.yaml.
- Support for specifying annotations/labels on the VPN add-on `NetworkPolicy`.
- Support for specifying custom podSelector labels on the VPN add-on `NetworkPolicy`.
- Added `secret` and `configMap` as persistence types.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

These are the docs to go along with the new persistence types: https://github.com/k8s-at-home/docs/pull/49

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
