### PR TITLE
[common] add ipFamilyPolicy and ipFamilies

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.1.0
+version: 4.2.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -64,6 +64,8 @@ N/A
 | addons.codeserver.image.tag | string | `"3.9.2"` | Specify the code-server image tag |
 | addons.codeserver.ingress.enabled | bool | `false` | Enable an ingress for the code-server add-on. |
 | addons.codeserver.service.enabled | bool | `true` | Enable a service for the code-server add-on. |
+| addons.codeserver.service.ipFamilies | list | `["IPv4"]` | The ip families that should be used. Options: IPv4, IPv6 |
+| addons.codeserver.service.ipFamilyPolicy | string | `"SingleStack"` | Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack |
 | addons.codeserver.volumeMounts | list | `[]` | Specify a list of volumes that get mounted in the code-server container. At least 1 volumeMount is required! |
 | addons.codeserver.workingDir | string | `""` | Specify the working dir that will be opened when code-server starts If not given, the app will default to the mountpah of the first specified volumeMount |
 | addons.netshoot | object | See values.yaml | The common library supports adding a netshoot add-on to troubleshoot network issues within a Pod. It can be configured under this key. |

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -224,6 +224,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.2.0]
+
+#### Added
+
+- Support for defining ipFamilyPolicy and ipFamilies in service resources
+
 ### [4.1.0]
 
 #### Changed

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.2.0]
+
+#### Added
+
+- Support for defining ipFamilyPolicy and ipFamilies in service resources
+
 ### [4.1.0]
 
 #### Changed

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -68,6 +68,13 @@ spec:
   {{- if $values.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ $values.publishNotReadyAddresses }}
   {{- end }}
+  {{- if $values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ $values.ipFamilyPolicy }}
+  {{- end }}
+  {{- with $values.ipFamilies }}
+  ipFamilies:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   ports:
   {{- range $name, $port := $values.ports }}
   {{- if $port.enabled }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -619,9 +619,9 @@ addons:
           # nodePort:
       annotations: {}
       labels: {}
-      # Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack
+      # -- Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack
       ipFamilyPolicy: SingleStack
-      # The ip families that should be used. Options: IPv4, IPv6
+      # -- The ip families that should be used. Options: IPv4, IPv6
       ipFamilies:
         - IPv4
 

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -619,6 +619,11 @@ addons:
           # nodePort:
       annotations: {}
       labels: {}
+      # Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack
+      ipFamilyPolicy: SingleStack
+      # The ip families that should be used. Options: IPv4, IPv6
+      ipFamilies:
+        - IPv4
 
     ingress:
       # -- Enable an ingress for the code-server add-on.


### PR DESCRIPTION
**Description of the change**
This PR adds support for new configurations options for the service resource. Since 1.22 Kubernetes (more specifically the k3s version) has support for dual stack IPv4/IPv6. But if you want to use that feature, you need to specify `ipFamilyPolicy` and `ipFamilies` on services that are directly exposed (`type: LoadBalancer`). This PR enables these options.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
See above.

**Possible drawbacks**
None.

**Applicable issues**
None yet.

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
