### PR TITLE
[common] Add support for runtimeClassName configuration

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.2.0
+version: 4.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -190,6 +190,7 @@ N/A
 | probes.startup.enabled | bool | `true` | Enable the startup probe |
 | probes.startup.spec | object | See below | The spec field contains the values for the default startupProbe. If you selected `custom: true`, this field holds the definition of the startupProbe. |
 | resources | object | `{}` | Set the resource requests / limits for the main container. |
+| runtimeClassName | string | `nil` | Allow specifying a runtimeClassName other than the default one (ie: nvidia)
 | schedulerName | string | `nil` | Allows specifying a custom scheduler name |
 | secret | object | `{}` | Use this to populate a secret with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. |
 | securityContext | object | `{}` | Configure the Security Context for the main container |
@@ -224,6 +225,11 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.3.0]
+
+#### Added
+
+- Support for setting the runtimeClassName of the pods
 ### [4.2.0]
 
 #### Added

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -190,7 +190,7 @@ N/A
 | probes.startup.enabled | bool | `true` | Enable the startup probe |
 | probes.startup.spec | object | See below | The spec field contains the values for the default startupProbe. If you selected `custom: true`, this field holds the definition of the startupProbe. |
 | resources | object | `{}` | Set the resource requests / limits for the main container. |
-| runtimeClassName | string | `nil` | Allow specifying a runtimeClassName other than the default one (ie: nvidia)
+| runtimeClassName | string | `nil` | Allow specifying a runtimeClassName other than the default one (ie: nvidia) |
 | schedulerName | string | `nil` | Allows specifying a custom scheduler name |
 | secret | object | `{}` | Use this to populate a secret with the values you specify. Be aware that these values are not encrypted by default, and could therefore visible to anybody with access to the values.yaml file. |
 | securityContext | object | `{}` | Configure the Security Context for the main container |
@@ -230,6 +230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Support for setting the runtimeClassName of the pods
+
 ### [4.2.0]
 
 #### Added

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.3.0]
+
+#### Added
+
+- Support for setting the runtimeClassName of the pods
+
 ### [4.2.0]
 
 #### Added

--- a/charts/stable/common/templates/lib/controller/_pod.tpl
+++ b/charts/stable/common/templates/lib/controller/_pod.tpl
@@ -16,6 +16,9 @@ securityContext:
 priorityClassName: {{ . }}
   {{- end }}
   {{- with .Values.schedulerName }}
+runtimeClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.runtimeClassName }}
 schedulerName: {{ . }}
   {{- end }}
   {{- with .Values.hostNetwork }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -112,7 +112,7 @@ env:
 priorityClassName:  # system-node-critical
 
 # -- Allow specifying a runtimeClassName other than the default one (ie: nvidia)
-runtimeClassName: # nvidia
+runtimeClassName:  # nvidia
 
 # -- Allows specifying a custom scheduler name
 schedulerName:  # awkward-dangerous-scheduler

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -112,7 +112,7 @@ env:
 priorityClassName:  # system-node-critical
 
 # -- Allow specifying a runtimeClassName other than the default one (ie: nvidia)
-runtimeClassName: #nvidia
+runtimeClassName: # nvidia
 
 # -- Allows specifying a custom scheduler name
 schedulerName:  # awkward-dangerous-scheduler

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -111,6 +111,9 @@ env:
 # -- Custom priority class for different treatment by the scheduler
 priorityClassName:  # system-node-critical
 
+# -- Allow specifying a runtimeClassName other than the default one (ie: nvidia)
+runtimeClassName: #nvidia
+
 # -- Allows specifying a custom scheduler name
 schedulerName:  # awkward-dangerous-scheduler
 


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add the option to define a runtimeClassName to the pods deployed.

**Benefits**

This allows starting the pods using the nvidia runtime in a way that is compatible with k3s 1.22 [automatic nvidia discovery](https://github.com/k3s-io/k3s/pull/3890) which no longer make the nvidia container runtime the default one.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
