### PR TITLE
[common] Add ability to disable ipFamilies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,13 @@ charts/*/charts
 helper-charts/*/Chart.lock
 helper-charts/*/charts
 
-# Other rsources
+# Other resources
 .env
 .envrc
 Gemfile.lock
 
 # Trash
 .DS_Store
+
+# Vim
+*.swp

--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.2.0
+version: 4.2.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.2.1](https://img.shields.io/badge/Version-4.2.1-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -223,6 +223,12 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.2.1]
+
+#### Fixed
+
+- Add ability to disable ipFamilies to maintain k8s v1.19 support.
 
 ### [4.2.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.2.1]
+
+#### Fixed
+
+- Add ability to disable ipFamilies to maintain k8s v1.19 support.
+
 ### [4.2.0]
 
 #### Added

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -71,9 +71,11 @@ spec:
   {{- if $values.ipFamilyPolicy }}
   ipFamilyPolicy: {{ $values.ipFamilyPolicy }}
   {{- end }}
-  {{- with $values.ipFamilies }}
+  {{- if $values.ipFamilies }}
+  {{- with $values.ipFamilies -}}
   ipFamilies:
     {{ toYaml . | nindent 4 }}
+  {{- end -}}
   {{- end }}
   ports:
   {{- range $name, $port := $values.ports }}


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

While the `ipFamilyPolicy` can be removed from the spec, `ipFamilies` cannot. This breaks for those running k8s 1.19. I've wrapped it in an if so it can be removed from the spec just like `ipFamilyPolicy`.


**Benefits**

K8S at home helm charts don't break on those running k8s 1.19

**Possible drawbacks**

None that I can think of

**Applicable issues**

- fixes #109

**Additional information**

N/A

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
