### PR TITLE
[common] Add support for setting `hostPort` on pods

### DIFF
--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -203,6 +203,7 @@ N/A
 | service.main.nameOverride | string | `nil` | Override the name suffix that is used for this service |
 | service.main.ports | object | See below | Configure the Service port information here. Additional ports can be added by adding a dictionary key similar to the 'http' service. |
 | service.main.ports.http.enabled | bool | `true` | Enables or disables the port |
+| service.main.ports.http.hostPort | string | `nil` | Specify the hostPort value for pod to expose. |
 | service.main.ports.http.nodePort | string | `nil` | Specify the nodePort value for the LoadBalancer and NodePort service types. [[ref]](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |
 | service.main.ports.http.port | string | `nil` | The port number |
 | service.main.ports.http.primary | bool | `true` | Make this the primary port (used in probes, notes, etc...) If there is more than 1 service, make sure that only 1 port is marked as primary. |
@@ -226,6 +227,12 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.4.0]
+
+#### Added
+
+- Support setting `hostPort` on pods
 
 ### [4.3.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.4.0]
+
+#### Added
+
+- Support setting `hostPort` on pods
+
 ### [4.3.0]
 
 #### Added

--- a/charts/stable/common/templates/lib/controller/_ports.tpl
+++ b/charts/stable/common/templates/lib/controller/_ports.tpl
@@ -30,6 +30,9 @@ Ports included by the controller.
   {{- else }}
   protocol: TCP
   {{- end }}
+  {{- if .hostPort }}
+  hostPort: {{ .hostPort }}
+  {{- end }}
 {{- end}}
 {{- end -}}
 {{- end -}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -290,6 +290,9 @@ service:
         # [[ref]](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
         nodePort:
 
+        # -- Specify the hostPort value for pod to expose.
+        hostPort:
+
 # -- Configure the ingresses for the chart here.
 # Additional ingresses can be added by adding a dictionary key similar to the 'main' ingress.
 # @default -- See below


### PR DESCRIPTION
Signed-off-by: Utku Ozdemir <uoz@protonmail.com>

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Possibility to specify hostPort

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
none
<!-- Describe any known limitations with your change -->

**Applicable issues**
Simple alternative to MetalLB/proxies

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #116

**Additional information**
As discussed in Discord
Tested on the `common-test` chart inside the repo, working as expected

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
