### PR TITLE
[common] Allow overriding args for vpn containers

### DIFF
--- a/charts/stable/common/templates/addons/vpn/openvpn/_container.tpl
+++ b/charts/stable/common/templates/addons/vpn/openvpn/_container.tpl
@@ -16,6 +16,10 @@ env:
     value: {{ $v | quote }}
 {{- end }}
 {{- end }}
+args:
+{{- range .Values.addons.vpn.args }}
+- {{ . | quote }}
+{{- end }}
 {{- if or .Values.addons.vpn.openvpn.auth .Values.addons.vpn.openvpn.authSecret }}
 envFrom:
   - secretRef:

--- a/charts/stable/common/templates/addons/vpn/wireguard/_container.tpl
+++ b/charts/stable/common/templates/addons/vpn/wireguard/_container.tpl
@@ -16,6 +16,10 @@ env:
     value: {{ $v | quote }}
 {{- end }}
 {{- end }}
+args:
+{{- range .Values.addons.vpn.args }}
+- {{ . | quote }}
+{{- end }}
 {{- if or .Values.addons.vpn.configFile .Values.addons.vpn.configFileSecret .Values.addons.vpn.scripts.up .Values.addons.vpn.scripts.down .Values.addons.vpn.additionalVolumeMounts .Values.persistence.shared.enabled }}
 volumeMounts:
 {{- if or .Values.addons.vpn.configFile .Values.addons.vpn.configFileSecret }}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -511,6 +511,9 @@ addons:
     env: {}
       # TZ: UTC
 
+    # -- Override the args for the vpn sidecar container
+    args: []
+
     # -- Provide a customized vpn configuration file to be used by the VPN.
     configFile:  # |-
       # Some Example Config


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Allows custom arguments to be passed to VPN containers.

**Benefits**

Will allow additional configuration of VPN containers when environment variables are not enough.

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
