### PR TITLE
[common] Allow annotation with variable values specified in the value.yaml

### DIFF
--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       changed: ${{ steps.list-changed.outputs.changed }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '^1.16'
 

--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         version: v3.5.4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
 
@@ -101,7 +101,7 @@ jobs:
       with:
         version: v3.5.4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.7
 

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -43,7 +43,7 @@ jobs:
       with:
         version: v3.5.4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       if: steps.filter.outputs.addedOrModified == 'true'
       with:
         python-version: 3.7

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -23,7 +23,7 @@ jobs:
         private_key: ${{ secrets.K8S_AT_HOME_APP_PRIVATE_KEY }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ steps.get-app-token.outputs.token }}
         ref: ${{ github.ref }}
@@ -103,7 +103,7 @@ jobs:
         private_key: ${{ secrets.K8S_AT_HOME_APP_PRIVATE_KEY }}
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ steps.get-app-token.outputs.token }}
         ref: main

--- a/.github/workflows/metadata-label-commenter.yaml
+++ b/.github/workflows/metadata-label-commenter.yaml
@@ -27,7 +27,7 @@ jobs:
         app_id: ${{ secrets.K8S_AT_HOME_APP_ID }}
         private_key: ${{ secrets.K8S_AT_HOME_APP_PRIVATE_KEY }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ steps.get-app-token.outputs.token }}
         ref: main

--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/charts/stable/common/templates/_deployment.tpl
+++ b/charts/stable/common/templates/_deployment.tpl
@@ -42,9 +42,9 @@ spec:
       {{- include "common.labels.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{ if .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "common.labels.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
Allow annotation with variable values specified in the values.yaml

**Description of the change**
The change allows to add an annotation where the value is being evaluated within the template.

**Benefits**
With the change it is possible to have the pod restarted, if a linked configmap changes. This is described here: https://codersociety.com/blog/articles/helm-best-practices (under 8.).

the values.yaml could look like this:
```yaml
common:
  podAnnotations:
    checksum/config: "{{ include (print $.Template.BasePath \"/configmap.yaml\") . | sha256sum }}"
```

**Possible drawbacks**
I am not aware of any.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
