### PR TITLE
Add support for global labels

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.3.0
+version: 4.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -135,6 +135,7 @@ N/A
 | env | string | `nil` | Main environment variables. Template enabled. Syntax options: A) TZ: UTC B) PASSWD: '{{ .Release.Name }}' C) PASSWD:      configMapKeyRef:        name: config-map-name        key: key-name D) PASSWD:      valueFrom:        secretKeyRef:          name: secret-name          key: key-name      ... E) - name: TZ      value: UTC F) - name: TZ      value: '{{ .Release.Name }}' |
 | envFrom | list | `[]` | Secrets and/or ConfigMaps that will be loaded as environment variables. [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables) |
 | global.fullnameOverride | string | `nil` | Set the entire name definition |
+| global.labels | object | `{}` | Set additional global label. Helm templates can be used. |
 | global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
 | hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
@@ -226,6 +227,12 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.4.0]
+
+#### Added
+
+- Support additional global labels
 
 ### [4.3.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.4.0]
+
+#### Added
+
+- Support additional global labels
+
 ### [4.3.0]
 
 #### Added

--- a/charts/stable/common/templates/lib/chart/_labels.tpl
+++ b/charts/stable/common/templates/lib/chart/_labels.tpl
@@ -6,6 +6,13 @@ helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.global.labels }}
+    {{- range $k, $v := . }}
+      {{- $name := $k }}
+      {{- $value := tpl $v $ }}
+{{ $name }}: {{ quote $value }}
+    {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{/* Selector labels shared across objects */}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -3,6 +3,8 @@ global:
   nameOverride:
   # -- Set the entire name definition
   fullnameOverride:
+  # -- Set additional global label. Helm templates can be used.
+  labels: {}
 
 controller:
   # -- enable the controller.


### PR DESCRIPTION
**Description of the change**

This PR adds support for adding labels to all created resources.

**Benefits**

Makes it easier than drilling down to each resource

**Possible drawbacks**

I can't think of any?

**Applicable issues**

- fixes #153

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
