### PR TITLE
[common] Add global labels, with merge support

### DIFF
--- a/charts/stable/common/Chart.yaml
+++ b/charts/stable/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for k8s-at-home charts
 type: library
-version: 4.3.1
+version: 4.4.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - k8s-at-home

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
+![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square)
 
 Function library for k8s-at-home charts
 
@@ -135,6 +135,7 @@ N/A
 | env | string | `nil` | Main environment variables. Template enabled. Syntax options: A) TZ: UTC B) PASSWD: '{{ .Release.Name }}' C) PASSWD:      configMapKeyRef:        name: config-map-name        key: key-name D) PASSWD:      valueFrom:        secretKeyRef:          name: secret-name          key: key-name      ... E) - name: TZ      value: UTC F) - name: TZ      value: '{{ .Release.Name }}' |
 | envFrom | list | `[]` | Secrets and/or ConfigMaps that will be loaded as environment variables. [[ref]](https://unofficial-kubernetes.readthedocs.io/en/latest/tasks/configure-pod-container/configmap/#use-case-consume-configmap-in-environment-variables) |
 | global.fullnameOverride | string | `nil` | Set the entire name definition |
+| global.labels | object | `{}` | Set additional global label. Helm templates can be used. |
 | global.nameOverride | string | `nil` | Set an override for the prefix of the fullname |
 | hostAliases | list | `[]` | Use hostAliases to add custom entries to /etc/hosts - mapping IP addresses to hostnames. [[ref]](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | hostNetwork | bool | `false` | When using hostNetwork make sure you set dnsPolicy to `ClusterFirstWithHostNet` |
@@ -226,6 +227,12 @@ All notable changes to this library Helm chart will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [4.4.0]
+
+#### Added
+
+- Support additional global labels
 
 ### [4.3.0]
 

--- a/charts/stable/common/README_CHANGELOG.md.gotmpl
+++ b/charts/stable/common/README_CHANGELOG.md.gotmpl
@@ -10,6 +10,12 @@ All notable changes to this library Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [4.4.0]
+
+#### Added
+
+- Support additional global labels
+
 ### [4.3.0]
 
 #### Added

--- a/charts/stable/common/templates/_daemonset.tpl
+++ b/charts/stable/common/templates/_daemonset.tpl
@@ -8,14 +8,11 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.controller.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge .Values.controller.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.controller.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}

--- a/charts/stable/common/templates/_deployment.tpl
+++ b/charts/stable/common/templates/_deployment.tpl
@@ -8,14 +8,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.controller.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge .Values.controller.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.controller.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}

--- a/charts/stable/common/templates/_secret.tpl
+++ b/charts/stable/common/templates/_secret.tpl
@@ -7,8 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 {{- with .Values.secret }}
 stringData:

--- a/charts/stable/common/templates/_serviceaccount.tpl
+++ b/charts/stable/common/templates/_serviceaccount.tpl
@@ -7,10 +7,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "common.names.serviceAccountName" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/stable/common/templates/_statefulset.tpl
+++ b/charts/stable/common/templates/_statefulset.tpl
@@ -8,14 +8,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with .Values.controller.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge .Values.controller.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.controller.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}

--- a/charts/stable/common/templates/addons/code-server/_secret.tpl
+++ b/charts/stable/common/templates/addons/code-server/_secret.tpl
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}-deploykey
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 {{- if .Values.addons.codeserver.git.deployKey }}
 stringData:

--- a/charts/stable/common/templates/addons/promtail/_configmap.tpl
+++ b/charts/stable/common/templates/addons/promtail/_configmap.tpl
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-promtail
-  labels:
-  {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
 data:
   promtail.yaml: |
     server:

--- a/charts/stable/common/templates/addons/vpn/_configmap.tpl
+++ b/charts/stable/common/templates/addons/vpn/_configmap.tpl
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-vpn
-  labels:
-  {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
 data:
 {{- with .Values.addons.vpn.scripts.up }}
   up.sh: |-

--- a/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
+++ b/charts/stable/common/templates/addons/vpn/_networkpolicy.tpl
@@ -8,21 +8,17 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels:
-    {{- with .Values.addons.vpn.networkPolicy.labels }}
-       {{- toYaml . | nindent 4 }}
-    {{- end }}
-  annotations:
-    {{- with .Values.addons.vpn.networkPolicy.annotations }}
-      {{ toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge .Values.addons.vpn.networkPolicy.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.addons.vpn.networkPolicy.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
-    matchLabels:
-      {{- include "common.labels.selectorLabels" . | nindent 6 }}
-      {{- with .Values.addons.vpn.networkPolicy.podSelectorLabels }}
-        {{ toYaml . | nindent 6 }}
-      {{- end }}
+    {{- with (merge .Values.addons.vpn.networkPolicy.podSelectorLabels (include "common.labels.selectorLabels" . | fromYaml)) }}
+    matchLabels: {{- toYaml . | nindent 6 }}
+    {{- end }}
   policyTypes:
     - Egress
   egress:

--- a/charts/stable/common/templates/addons/vpn/_secret.tpl
+++ b/charts/stable/common/templates/addons/vpn/_secret.tpl
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-vpnconfig
-  labels:
-  {{- include "common.labels" $ | nindent 4 }}
+  labels: {{- include "common.labels" $ | nindent 4 }}
 stringData:
   {{- with .Values.addons.vpn.configFile }}
   vpnConfigfile: |-

--- a/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
+++ b/charts/stable/common/templates/addons/vpn/openvpn/_secret.tpl
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" $ }}-openvpn
-  labels:
-  {{- include "common.labels" $ | nindent 4 }}
+  labels: {{- include "common.labels" $ | nindent 4 }}
 data:
   VPN_AUTH: {{ . | b64enc }}
 {{- end -}}

--- a/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
+++ b/charts/stable/common/templates/classes/_HorizontalPodAutoscaler.tpl
@@ -11,8 +11,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $hpaName }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
+  labels: {{- include "common.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/stable/common/templates/classes/_configmap.tpl
+++ b/charts/stable/common/templates/classes/_configmap.tpl
@@ -21,14 +21,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $configMapName }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with $values.labels }}
-       {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge $values.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $values.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
 {{- with $values.data }}

--- a/charts/stable/common/templates/classes/_ingress.tpl
+++ b/charts/stable/common/templates/classes/_ingress.tpl
@@ -29,14 +29,11 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $ingressName }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with $values.labels }}
-       {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge $values.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $values.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if and $isStable $values.ingressClassName }}

--- a/charts/stable/common/templates/classes/_pvc.tpl
+++ b/charts/stable/common/templates/classes/_pvc.tpl
@@ -20,6 +20,9 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ $pvcName }}
+  {{- with (merge $values.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if or $values.retain $values.annotations }}
   annotations:
     {{- if $values.retain }}
@@ -28,11 +31,6 @@ metadata:
     {{- with $values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
-  labels:
-  {{- include "common.labels" . | nindent 4 }}
-  {{- with $values.labels }}
-    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:

--- a/charts/stable/common/templates/classes/_service.tpl
+++ b/charts/stable/common/templates/classes/_service.tpl
@@ -21,11 +21,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $serviceName }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    {{- with $values.labels }}
-       {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- with (merge $values.labels (include "common.labels" . | fromYaml)) }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if eq ( $primaryPort.protocol | default "" ) "HTTPS" }}
     traefik.ingress.kubernetes.io/service.serversscheme: https

--- a/charts/stable/common/templates/lib/chart/_labels.tpl
+++ b/charts/stable/common/templates/lib/chart/_labels.tpl
@@ -6,6 +6,13 @@ helm.sh/chart: {{ include "common.names.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
   {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.global.labels }}
+    {{- range $k, $v := . }}
+      {{- $name := $k }}
+      {{- $value := tpl $v $ }}
+{{ $name }}: {{ quote $value }}
+    {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{/* Selector labels shared across objects */}}

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -3,6 +3,8 @@ global:
   nameOverride:
   # -- Set the entire name definition
   fullnameOverride:
+  # -- Set additional global labels. Helm templates can be used.
+  labels: {}
 
 controller:
   # -- enable the controller.


### PR DESCRIPTION
**Description of the change**

This PR adds support for adding labels to all created resources, as well as updates all references to use merged objects.

**Benefits**

- Makes it easier than drilling down to each resource
- Prevents duplicates
- Bonus: code is slightly easier to read :D

**Possible drawbacks**

- Large blast radius

**Applicable issues**

- closes #154
- fixes #153

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
