### PR TITLE
[common] Add ingressClassName for codeserver addon to values.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-* @onedr0p @bjw-s @billimek @carpenike
+* @onedr0p @bjw-s @billimek @carpenike @truxnell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-* @onedr0p @bjw-s @billimek @carpenike @truxnell
+* @onedr0p @bjw-s @billimek @carpenike @Truxnell

--- a/charts/stable/common/values.yaml
+++ b/charts/stable/common/values.yaml
@@ -671,6 +671,11 @@ addons:
         # kubernetes.io/tls-acme: "true"
 
       labels: {}
+
+      # -- Set the ingressClass that is used for this ingress.
+      # Requires Kubernetes >=1.19
+      ingressClassName:  # "nginx"
+
       hosts:
         - host: code.chart-example.local
           paths:


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

This should already work. Due to fact that codeserver ingress goes through the ingress templating, although nice to document that it is possible.

This does not require a bump to Chart.yaml as it is already possible to apply `ingressClassName`

**Benefits**

Transparency when looking through values.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
