### PR TITLE
[common] add /template/common.yaml reference in readme.md

### DIFF
--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -33,7 +33,7 @@ dependencies:
   repository: https://k8s-at-home.com/charts/
 ```
 
-Create a reference file `/template/common.yaml` with at least this line:
+Create a reference file `./template/common.yaml` with at least this line:
 ```yaml
 {{ include "common.all" . }}
 ```

--- a/charts/stable/common/README.md
+++ b/charts/stable/common/README.md
@@ -33,6 +33,11 @@ dependencies:
   repository: https://k8s-at-home.com/charts/
 ```
 
+Create a reference file `/template/common.yaml` with at least this line:
+```yaml
+{{ include "common.all" . }}
+```
+
 For more information, take a look at the [Docs](http://docs.k8s-at-home.com/our-helm-charts/common-library/).
 
 ## Configuration


### PR DESCRIPTION
`helm upgrade --install` passes and deploys the chart without installing any resources to the cluster, if common is never referenced in the template folder. see this thread https://discord.com/channels/673534664354430999/999329945937531001/999397476828192838
